### PR TITLE
Add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Linux
+          - goos: linux
+            goarch: amd64
+            suffix: ""
+          - goos: linux
+            goarch: arm64
+            suffix: ""
+          # macOS
+          - goos: darwin
+            goarch: amd64
+            suffix: ""
+          - goos: darwin
+            goarch: arm64
+            suffix: ""
+          # Windows
+          - goos: windows
+            goarch: amd64
+            suffix: ".exe"
+          - goos: windows
+            goarch: arm64
+            suffix: ".exe"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -v -o switchboard-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }} ./cmd/switchboard
+          ls -lh switchboard-*
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: switchboard-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: switchboard-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds a CI workflow to build the switchboard binary for all major platforms and architectures.

## Changes

- New workflow: `.github/workflows/build.yml`
- Builds on every push to main and on pull requests
- Uses matrix strategy for parallel builds

## Platforms

Builds for 6 platform/architecture combinations:

| Platform | Architecture | Output |
|----------|-------------|---------|
| Linux | amd64 | `switchboard-linux-amd64` |
| Linux | arm64 | `switchboard-linux-arm64` |
| macOS | amd64 | `switchboard-darwin-amd64` |
| macOS | arm64 | `switchboard-darwin-arm64` |
| Windows | amd64 | `switchboard-windows-amd64.exe` |
| Windows | arm64 | `switchboard-windows-arm64.exe` |

## Artifacts

Each build uploads its binary as a GitHub Actions artifact, making it easy to download and test builds from PRs.

## Testing

Verified local build works:
```bash
go build -v -o switchboard-test ./cmd/switchboard
```

This workflow will ensure all platforms can build successfully before merging changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)