### PR TITLE
Improve browser detection and add profile support

### DIFF
--- a/cmd/switchboard/cmd_init.go
+++ b/cmd/switchboard/cmd_init.go
@@ -26,15 +26,47 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("configuration file already exists at %s", configPath)
 	}
 
-	// Get default config
+	// Detect installed browsers
+	detector := createDetector(nil)
+	browsers := detector.DetectAll()
+
+	if len(browsers) == 0 {
+		return fmt.Errorf("no browsers detected on your system")
+	}
+
+	// Display detected browsers
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Detected %d browser(s):\n", len(browsers))
+	for name := range browsers {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  - %s\n", name)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+
+	// Ask user to choose default browser
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), "Enter the name of your default browser: ")
+	var defaultBrowser string
+	if _, err := fmt.Fscanln(cmd.InOrStdin(), &defaultBrowser); err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// Validate chosen browser
+	if _, ok := browsers[defaultBrowser]; !ok {
+		return fmt.Errorf("browser '%s' was not detected. Please choose from the list above", defaultBrowser)
+	}
+
+	// Create config with detected browsers (using "auto" for paths)
 	cfg := config.GetDefaultConfig()
+	cfg.DefaultBrowser = defaultBrowser
+	for name := range browsers {
+		cfg.Browsers[name] = config.Browser{Path: "auto"}
+	}
 
 	// Save config
 	if err := cfg.SaveTo(configPath); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Created configuration file at: %s\n", configPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nCreated configuration file at: %s\n", configPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Default browser set to: %s\n", defaultBrowser)
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nEdit this file to customize your browser routing rules.")
 
 	return nil

--- a/cmd/switchboard/cmd_init_test.go
+++ b/cmd/switchboard/cmd_init_test.go
@@ -15,19 +15,24 @@ func TestRunInit(t *testing.T) {
 	tests := []struct {
 		name           string
 		setupFunc      func(tempDir string) string // Returns config path to use
+		stdinInput     string                      // Input for the interactive prompt
 		wantErr        bool
 		wantErrContain string
 		wantOutput     []string
 		checkFile      func(t *testing.T, configPath string)
 	}{
 		{
-			name: "successful init - new config",
+			name: "successful init - new config with chrome",
 			setupFunc: func(tempDir string) string {
 				return filepath.Join(tempDir, "config.yaml")
 			},
-			wantErr: false,
+			stdinInput: "chrome\n",
+			wantErr:    false,
 			wantOutput: []string{
+				"Detected",
+				"browser(s)",
 				"Created configuration file at:",
+				"Default browser set to: chrome",
 				"Edit this file to customize your browser routing rules",
 			},
 			checkFile: func(t *testing.T, configPath string) {
@@ -41,11 +46,23 @@ func TestRunInit(t *testing.T) {
 					}
 					content := string(data)
 					// Check for some expected content
-					if !strings.Contains(content, "defaultBrowser") {
-						t.Error("Created config should contain defaultBrowser field")
+					if !strings.Contains(content, "defaultBrowser: chrome") {
+						t.Error("Created config should contain defaultBrowser: chrome")
+					}
+					if !strings.Contains(content, "browsers:") {
+						t.Error("Created config should contain browsers section")
 					}
 				}
 			},
+		},
+		{
+			name: "init fails - invalid browser choice",
+			setupFunc: func(tempDir string) string {
+				return filepath.Join(tempDir, "config.yaml")
+			},
+			stdinInput:     "doesnotexist\n",
+			wantErr:        true,
+			wantErrContain: "was not detected",
 		},
 		{
 			name: "init fails - config already exists",
@@ -54,6 +71,7 @@ func TestRunInit(t *testing.T) {
 				_ = os.WriteFile(configPath, []byte("defaultBrowser: firefox\n"), 0644)
 				return configPath
 			},
+			stdinInput:     "chrome\n",
 			wantErr:        true,
 			wantErrContain: "configuration file already exists",
 		},
@@ -63,6 +81,7 @@ func TestRunInit(t *testing.T) {
 				// Return a path in a non-existent directory
 				return "/nonexistent/directory/that/does/not/exist/config.yaml"
 			},
+			stdinInput:     "chrome\n",
 			wantErr:        true,
 			wantErrContain: "failed to save config",
 		},
@@ -79,8 +98,11 @@ func TestRunInit(t *testing.T) {
 			})
 			defer config.SetConfigPathProvider(oldProvider)
 
-			// Capture output
+			// Capture output and provide input
 			var buf bytes.Buffer
+			var inBuf bytes.Buffer
+			inBuf.WriteString(tt.stdinInput)
+
 			iniCmd := &cobra.Command{
 				Use:  initCmd.Use,
 				Args: initCmd.Args,
@@ -88,6 +110,7 @@ func TestRunInit(t *testing.T) {
 			}
 			iniCmd.SetOut(&buf)
 			iniCmd.SetErr(&buf)
+			iniCmd.SetIn(&inBuf)
 
 			err := runInit(iniCmd, []string{})
 

--- a/cmd/switchboard/cmd_list_browsers.go
+++ b/cmd/switchboard/cmd_list_browsers.go
@@ -14,12 +14,8 @@ var listBrowsersCmd = &cobra.Command{
 }
 
 func runListBrowsers(cmd *cobra.Command, args []string) error {
-	cfg, err := loadConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	detector := createDetector(cfg)
+	// list-browsers doesn't need config - it just detects all browsers
+	detector := createDetector(nil)
 	browsers := detector.DetectAll()
 
 	if len(browsers) == 0 {
@@ -30,7 +26,15 @@ func runListBrowsers(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Detected %d browser(s):\n\n", len(browsers))
 	for _, br := range browsers {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", br.Name)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Path: %s\n\n", br.Path)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Path: %s\n", br.Path)
+
+		if len(br.Profiles) > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Profiles:\n")
+			for _, profile := range br.Profiles {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "      - %s (%s)\n", profile.Name, profile.Directory)
+			}
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 	}
 
 	return nil

--- a/internal/browser/detector.go
+++ b/internal/browser/detector.go
@@ -36,14 +36,15 @@ func (d *Detector) Detect(name string) (*Browser, error) {
 	d.cacheMux.RUnlock()
 
 	// Check if user specified a custom path in config
-	if d.config.Browsers != nil {
+	if d.config != nil && d.config.Browsers != nil {
 		if browserCfg, ok := d.config.Browsers[name]; ok {
 			if browserCfg.Path != "" && browserCfg.Path != "auto" {
 				// Verify the path exists
 				if _, err := os.Stat(browserCfg.Path); err == nil {
 					browser := &Browser{
-						Name: name,
-						Path: browserCfg.Path,
+						Name:     name,
+						Path:     browserCfg.Path,
+						Profiles: DetectProfiles(name),
 					}
 					d.cacheResult(name, browser)
 					return browser, nil
@@ -62,8 +63,9 @@ func (d *Detector) Detect(name string) (*Browser, error) {
 	for _, path := range browserDef.GetPaths() {
 		if _, err := os.Stat(path); err == nil {
 			browser := &Browser{
-				Name: name,
-				Path: path,
+				Name:     name,
+				Path:     path,
+				Profiles: DetectProfiles(name),
 			}
 			d.cacheResult(name, browser)
 			return browser, nil
@@ -76,8 +78,9 @@ func (d *Detector) Detect(name string) (*Browser, error) {
 		absPath, err := filepath.Abs(path)
 		if err == nil {
 			browser := &Browser{
-				Name: name,
-				Path: absPath,
+				Name:     name,
+				Path:     absPath,
+				Profiles: DetectProfiles(name),
 			}
 			d.cacheResult(name, browser)
 			return browser, nil
@@ -92,8 +95,9 @@ func (d *Detector) Detect(name string) (*Browser, error) {
 				absPath, err := filepath.Abs(path)
 				if err == nil {
 					browser := &Browser{
-						Name: name,
-						Path: absPath,
+						Name:     name,
+						Path:     absPath,
+						Profiles: DetectProfiles(name),
 					}
 					d.cacheResult(name, browser)
 					return browser, nil

--- a/internal/browser/profile.go
+++ b/internal/browser/profile.go
@@ -1,0 +1,287 @@
+package browser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Profile represents a browser profile
+type Profile struct {
+	Name      string
+	Directory string
+}
+
+// getProfileDirFunc is a function variable that can be mocked in tests
+var getProfileDirFunc = getProfileDirImpl
+
+// getProfileDir returns the profile directory for a browser
+func getProfileDir(browserName string) string {
+	return getProfileDirFunc(browserName)
+}
+
+// getProfileDirImpl is the actual implementation
+func getProfileDirImpl(browserName string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return getDarwinProfileDir(homeDir, browserName)
+	case "linux":
+		return getLinuxProfileDir(homeDir, browserName)
+	case "windows":
+		return getWindowsProfileDir(browserName)
+	default:
+		return ""
+	}
+}
+
+func getDarwinProfileDir(homeDir, browserName string) string {
+	appSupportDir := filepath.Join(homeDir, "Library", "Application Support")
+
+	switch browserName {
+	case "chrome":
+		return filepath.Join(appSupportDir, "Google", "Chrome")
+	case "brave":
+		return filepath.Join(appSupportDir, "BraveSoftware", "Brave-Browser")
+	case "edge":
+		return filepath.Join(appSupportDir, "Microsoft Edge")
+	case "chromium":
+		return filepath.Join(appSupportDir, "Chromium")
+	case "vivaldi":
+		return filepath.Join(appSupportDir, "Vivaldi")
+	case "firefox":
+		return filepath.Join(appSupportDir, "Firefox")
+	default:
+		return ""
+	}
+}
+
+func getLinuxProfileDir(homeDir, browserName string) string {
+	configDir := filepath.Join(homeDir, ".config")
+
+	switch browserName {
+	case "chrome":
+		return filepath.Join(configDir, "google-chrome")
+	case "brave":
+		// Try different possible locations
+		dirs := []string{
+			filepath.Join(configDir, "BraveSoftware", "Brave-Browser"),
+			filepath.Join(configDir, "brave"),
+		}
+		for _, dir := range dirs {
+			if _, err := os.Stat(dir); err == nil {
+				return dir
+			}
+		}
+		return ""
+	case "edge":
+		return filepath.Join(configDir, "microsoft-edge")
+	case "chromium":
+		return filepath.Join(configDir, "chromium")
+	case "vivaldi":
+		return filepath.Join(configDir, "vivaldi")
+	case "firefox":
+		return filepath.Join(homeDir, ".mozilla", "firefox")
+	default:
+		return ""
+	}
+}
+
+func getWindowsProfileDir(browserName string) string {
+	localAppData := os.Getenv("LOCALAPPDATA")
+	appData := os.Getenv("APPDATA")
+
+	if localAppData == "" && appData == "" {
+		return ""
+	}
+
+	switch browserName {
+	case "chrome":
+		return filepath.Join(localAppData, "Google", "Chrome", "User Data")
+	case "brave":
+		return filepath.Join(localAppData, "BraveSoftware", "Brave-Browser", "User Data")
+	case "edge":
+		return filepath.Join(localAppData, "Microsoft", "Edge", "User Data")
+	case "chromium":
+		return filepath.Join(localAppData, "Chromium", "User Data")
+	case "vivaldi":
+		return filepath.Join(localAppData, "Vivaldi", "User Data")
+	case "firefox":
+		return filepath.Join(appData, "Mozilla", "Firefox", "Profiles")
+	default:
+		return ""
+	}
+}
+
+// DetectProfiles detects profiles for a browser
+func DetectProfiles(browserName string) []Profile {
+	switch browserName {
+	case "chrome", "brave", "edge", "chromium", "vivaldi":
+		return detectChromiumProfiles(browserName)
+	case "firefox":
+		return detectFirefoxProfiles()
+	default:
+		return nil
+	}
+}
+
+// detectChromiumProfiles detects profiles for Chromium-based browsers
+func detectChromiumProfiles(browserName string) []Profile {
+	profileDir := getProfileDir(browserName)
+	if profileDir == "" {
+		return nil
+	}
+
+	// Check if profile directory exists
+	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	var profiles []Profile
+
+	// Check for "Default" profile
+	defaultProfile := filepath.Join(profileDir, "Default")
+	if _, err := os.Stat(defaultProfile); err == nil {
+		name := getChromiumProfileName(defaultProfile)
+		if name == "" {
+			name = "Default"
+		}
+		profiles = append(profiles, Profile{
+			Name:      name,
+			Directory: "Default",
+		})
+	}
+
+	// Check for additional profiles (Profile 1, Profile 2, etc.)
+	entries, err := os.ReadDir(profileDir)
+	if err != nil {
+		return profiles
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		// Check if it's a profile directory (Profile 1, Profile 2, etc.)
+		if strings.HasPrefix(name, "Profile ") {
+			profilePath := filepath.Join(profileDir, name)
+			profileName := getChromiumProfileName(profilePath)
+			if profileName == "" {
+				profileName = name
+			}
+			profiles = append(profiles, Profile{
+				Name:      profileName,
+				Directory: name,
+			})
+		}
+	}
+
+	return profiles
+}
+
+// getChromiumProfileName reads the profile name from Preferences file
+func getChromiumProfileName(profilePath string) string {
+	prefsPath := filepath.Join(profilePath, "Preferences")
+	data, err := os.ReadFile(prefsPath)
+	if err != nil {
+		return ""
+	}
+
+	var prefs struct {
+		Profile struct {
+			Name string `json:"name"`
+		} `json:"profile"`
+	}
+
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return ""
+	}
+
+	return prefs.Profile.Name
+}
+
+// detectFirefoxProfiles detects Firefox profiles
+func detectFirefoxProfiles() []Profile {
+	profileDir := getProfileDir("firefox")
+	if profileDir == "" {
+		return nil
+	}
+
+	// Check if profile directory exists
+	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	// Firefox uses profiles.ini to list profiles
+	profilesIni := filepath.Join(profileDir, "profiles.ini")
+	data, err := os.ReadFile(profilesIni)
+	if err != nil {
+		return nil
+	}
+
+	return parseFirefoxProfilesIni(string(data))
+}
+
+// parseFirefoxProfilesIni parses Firefox's profiles.ini file
+func parseFirefoxProfilesIni(content string) []Profile {
+	var profiles []Profile
+	lines := strings.Split(content, "\n")
+
+	var currentProfile *Profile
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Start of a profile section
+		if strings.HasPrefix(line, "[Profile") {
+			if currentProfile != nil {
+				profiles = append(profiles, *currentProfile)
+			}
+			currentProfile = &Profile{}
+			continue
+		}
+
+		// End of profiles.ini or start of different section
+		if strings.HasPrefix(line, "[") && !strings.HasPrefix(line, "[Profile") {
+			if currentProfile != nil {
+				profiles = append(profiles, *currentProfile)
+				currentProfile = nil
+			}
+			continue
+		}
+
+		if currentProfile == nil {
+			continue
+		}
+
+		// Parse key=value pairs
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "Name":
+			currentProfile.Name = value
+		case "Path":
+			currentProfile.Directory = value
+		}
+	}
+
+	// Add the last profile
+	if currentProfile != nil && currentProfile.Name != "" {
+		profiles = append(profiles, *currentProfile)
+	}
+
+	return profiles
+}

--- a/internal/browser/profile_test.go
+++ b/internal/browser/profile_test.go
@@ -1,0 +1,270 @@
+package browser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectProfiles_Chromium(t *testing.T) {
+	// Create a temporary Chrome-like profile directory structure
+	tempDir := t.TempDir()
+
+	// Create "Default" profile
+	defaultDir := filepath.Join(tempDir, "Default")
+	if err := os.MkdirAll(defaultDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Preferences file for Default profile
+	prefsDefault := `{"profile": {"name": "Person 1"}}`
+	if err := os.WriteFile(filepath.Join(defaultDir, "Preferences"), []byte(prefsDefault), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create "Profile 1" profile
+	profile1Dir := filepath.Join(tempDir, "Profile 1")
+	if err := os.MkdirAll(profile1Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Preferences file for Profile 1
+	prefsProfile1 := `{"profile": {"name": "Work"}}`
+	if err := os.WriteFile(filepath.Join(profile1Dir, "Preferences"), []byte(prefsProfile1), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create "Profile 2" profile
+	profile2Dir := filepath.Join(tempDir, "Profile 2")
+	if err := os.MkdirAll(profile2Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Preferences file for Profile 2
+	prefsProfile2 := `{"profile": {"name": "Personal"}}`
+	if err := os.WriteFile(filepath.Join(profile2Dir, "Preferences"), []byte(prefsProfile2), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock getProfileDir to return our temp directory
+	originalGetProfileDir := getProfileDirFunc
+	defer func() { getProfileDirFunc = originalGetProfileDir }()
+	getProfileDirFunc = func(browserName string) string {
+		return tempDir
+	}
+
+	profiles := detectChromiumProfiles("chrome")
+
+	if len(profiles) != 3 {
+		t.Errorf("Expected 3 profiles, got %d", len(profiles))
+	}
+
+	// Check Default profile
+	if profiles[0].Name != "Person 1" {
+		t.Errorf("Expected 'Person 1', got '%s'", profiles[0].Name)
+	}
+	if profiles[0].Directory != "Default" {
+		t.Errorf("Expected 'Default', got '%s'", profiles[0].Directory)
+	}
+
+	// Check Profile 1
+	if profiles[1].Name != "Work" {
+		t.Errorf("Expected 'Work', got '%s'", profiles[1].Name)
+	}
+	if profiles[1].Directory != "Profile 1" {
+		t.Errorf("Expected 'Profile 1', got '%s'", profiles[1].Directory)
+	}
+
+	// Check Profile 2
+	if profiles[2].Name != "Personal" {
+		t.Errorf("Expected 'Personal', got '%s'", profiles[2].Name)
+	}
+	if profiles[2].Directory != "Profile 2" {
+		t.Errorf("Expected 'Profile 2', got '%s'", profiles[2].Directory)
+	}
+}
+
+func TestDetectProfiles_Chromium_NoPreferences(t *testing.T) {
+	// Create a temporary Chrome-like profile directory structure without Preferences
+	tempDir := t.TempDir()
+
+	// Create "Default" profile without Preferences file
+	defaultDir := filepath.Join(tempDir, "Default")
+	if err := os.MkdirAll(defaultDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock getProfileDir to return our temp directory
+	originalGetProfileDir := getProfileDirFunc
+	defer func() { getProfileDirFunc = originalGetProfileDir }()
+	getProfileDirFunc = func(browserName string) string {
+		return tempDir
+	}
+
+	profiles := detectChromiumProfiles("chrome")
+
+	if len(profiles) != 1 {
+		t.Errorf("Expected 1 profile, got %d", len(profiles))
+	}
+
+	// Should use directory name as fallback
+	if profiles[0].Name != "Default" {
+		t.Errorf("Expected 'Default', got '%s'", profiles[0].Name)
+	}
+}
+
+func TestDetectProfiles_Firefox(t *testing.T) {
+	// Create a temporary Firefox-like profile directory structure
+	tempDir := t.TempDir()
+
+	// Create profiles.ini file
+	profilesIni := `[Profile0]
+Name=default-release
+IsRelative=1
+Path=abc123.default-release
+Default=1
+
+[Profile1]
+Name=dev
+IsRelative=1
+Path=xyz456.dev
+
+[General]
+StartWithLastProfile=1
+Version=2
+`
+	if err := os.WriteFile(filepath.Join(tempDir, "profiles.ini"), []byte(profilesIni), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock getProfileDir to return our temp directory
+	originalGetProfileDir := getProfileDirFunc
+	defer func() { getProfileDirFunc = originalGetProfileDir }()
+	getProfileDirFunc = func(browserName string) string {
+		return tempDir
+	}
+
+	profiles := detectFirefoxProfiles()
+
+	if len(profiles) != 2 {
+		t.Errorf("Expected 2 profiles, got %d", len(profiles))
+	}
+
+	// Check first profile
+	if profiles[0].Name != "default-release" {
+		t.Errorf("Expected 'default-release', got '%s'", profiles[0].Name)
+	}
+	if profiles[0].Directory != "abc123.default-release" {
+		t.Errorf("Expected 'abc123.default-release', got '%s'", profiles[0].Directory)
+	}
+
+	// Check second profile
+	if profiles[1].Name != "dev" {
+		t.Errorf("Expected 'dev', got '%s'", profiles[1].Name)
+	}
+	if profiles[1].Directory != "xyz456.dev" {
+		t.Errorf("Expected 'xyz456.dev', got '%s'", profiles[1].Directory)
+	}
+}
+
+func TestParseFirefoxProfilesIni(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []Profile
+	}{
+		{
+			name: "two profiles",
+			content: `[Profile0]
+Name=default
+Path=abc.default
+
+[Profile1]
+Name=work
+Path=xyz.work
+`,
+			expected: []Profile{
+				{Name: "default", Directory: "abc.default"},
+				{Name: "work", Directory: "xyz.work"},
+			},
+		},
+		{
+			name: "profile with extra fields",
+			content: `[Profile0]
+Name=default
+IsRelative=1
+Path=abc.default
+Default=1
+
+[General]
+StartWithLastProfile=1
+`,
+			expected: []Profile{
+				{Name: "default", Directory: "abc.default"},
+			},
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: []Profile{},
+		},
+		{
+			name: "profile without name",
+			content: `[Profile0]
+Path=abc.default
+`,
+			expected: []Profile{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profiles := parseFirefoxProfilesIni(tt.content)
+
+			if len(profiles) != len(tt.expected) {
+				t.Errorf("Expected %d profiles, got %d", len(tt.expected), len(profiles))
+				return
+			}
+
+			for i, profile := range profiles {
+				if profile.Name != tt.expected[i].Name {
+					t.Errorf("Profile %d: expected name '%s', got '%s'", i, tt.expected[i].Name, profile.Name)
+				}
+				if profile.Directory != tt.expected[i].Directory {
+					t.Errorf("Profile %d: expected directory '%s', got '%s'", i, tt.expected[i].Directory, profile.Directory)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectProfiles_UnsupportedBrowser(t *testing.T) {
+	profiles := DetectProfiles("safari")
+	if profiles != nil {
+		t.Errorf("Expected nil profiles for Safari, got %d profiles", len(profiles))
+	}
+
+	profiles = DetectProfiles("unknown")
+	if profiles != nil {
+		t.Errorf("Expected nil profiles for unknown browser, got %d profiles", len(profiles))
+	}
+}
+
+func TestDetectProfiles_NonexistentDirectory(t *testing.T) {
+	// Mock getProfileDir to return a non-existent directory
+	originalGetProfileDir := getProfileDirFunc
+	defer func() { getProfileDirFunc = originalGetProfileDir }()
+	getProfileDirFunc = func(browserName string) string {
+		return "/nonexistent/directory/that/does/not/exist"
+	}
+
+	profiles := detectChromiumProfiles("chrome")
+	if profiles != nil {
+		t.Errorf("Expected nil profiles for non-existent directory, got %d profiles", len(profiles))
+	}
+
+	profiles = detectFirefoxProfiles()
+	if profiles != nil {
+		t.Errorf("Expected nil profiles for non-existent directory, got %d profiles", len(profiles))
+	}
+}

--- a/internal/browser/registry.go
+++ b/internal/browser/registry.go
@@ -4,8 +4,9 @@ import "runtime"
 
 // Browser represents a detected browser
 type Browser struct {
-	Name string
-	Path string
+	Name     string
+	Path     string
+	Profiles []Profile
 }
 
 // BrowserDef defines a browser and its potential paths


### PR DESCRIPTION
## Summary

This PR implements three improvements to browser detection:

1. **list-browsers no longer requires config** - The command now works without a configuration file by making the detector's config parameter optional
2. **init command includes all detected browsers** - Automatically detects all browsers, asks user interactively which to use as default, and creates config with all browsers using "auto" paths
3. **Profile detection for Chrome/Firefox browsers** - Detects and displays profiles for Chromium-based browsers (Chrome, Brave, Edge, Chromium, Vivaldi) and Firefox

## Changes

### list-browsers improvements
- Made `Detector` config parameter optional with nil checks
- Command now detects all browsers without requiring configuration file
- Displays browser profiles when available

### init command improvements
- Auto-detects all installed browsers on the system
- Displays detected browsers to user
- Asks user interactively which browser to use as default
- Validates user's choice against detected browsers
- Creates config with all detected browsers using "auto" for paths
- Sets user's chosen browser as default

### Profile detection
- Created `profile.go` with profile detection for:
  - **Chromium-based browsers**: Detects "Default" and "Profile N" directories, reads profile names from Preferences JSON
  - **Firefox**: Parses profiles.ini to extract profile names and directories
- Updated `Browser` struct to include `Profiles` field
- Cross-platform support for macOS, Linux, and Windows

## Testing

- All existing tests pass
- Added comprehensive profile detection tests
- Race detector passes
- Linter clean (0 issues)

## Example Output

```
$ switchboard list-browsers
Detected 3 browser(s):

  chrome
    Path: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
    Profiles:
      - Privé (Default)
      - Werk (Profile 1)

  vivaldi
    Path: /Applications/Vivaldi.app/Contents/MacOS/Vivaldi
    Profiles:
      - Privé (Default)
      - Work (Profile 1)

  safari
    Path: /Applications/Safari.app/Contents/MacOS/Safari
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)