### PR TITLE
Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A smart URL router that opens links in different browsers based on configurable 
 ### Building from source
 
 ```bash
-go build -o switchboard cmd/switchboard/main.go
+go build -o switchboard ./cmd/switchboard
 ```
 
 ### Register as a browser


### PR DESCRIPTION
## Summary

Fixes the build command in the README that was failing.

## Problem

The command `go build -o switchboard cmd/switchboard/main.go` only compiles `main.go` and doesn't include the other files in the package (cmd_*.go files), causing undefined references to `openCmd`, `testCmd`, etc.

## Solution

Changed to `go build -o switchboard ./cmd/switchboard` which correctly builds all files in the package.

## Testing

```bash
$ go build -o switchboard ./cmd/switchboard
$ ./switchboard --version
switchboard version 0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)