### PR TITLE
Add URL rewriting support

### DIFF
--- a/cmd/switchboard/cmd_open.go
+++ b/cmd/switchboard/cmd_open.go
@@ -35,10 +35,16 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	logger.Info("Opening URL: %s", url)
 
 	rtr := createRouter(cfg)
-	browserName, profile, incognito, matched := rtr.FindMatch(url)
+	browserName, profile, incognito, matched, rewrittenURL := rtr.FindMatch(url)
 
 	if !matched {
 		logger.Info("No rule matched, using default browser: %s", browserName)
+	}
+
+	// Use the rewritten URL if different from original
+	urlToOpen := rewrittenURL
+	if urlToOpen != url {
+		logger.Info("Using rewritten URL: %s", urlToOpen)
 	}
 
 	detector := createDetector(cfg)
@@ -48,10 +54,10 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	}
 
 	lnch := createLauncher(cfg)
-	if err := lnch.Launch(br, url, profile, incognito); err != nil {
+	if err := lnch.Launch(br, urlToOpen, profile, incognito); err != nil {
 		return fmt.Errorf("failed to launch browser: %w", err)
 	}
 
-	logger.Info("Successfully opened %s in %s", url, browserName)
+	logger.Info("Successfully opened %s in %s", urlToOpen, browserName)
 	return nil
 }

--- a/cmd/switchboard/cmd_test_url.go
+++ b/cmd/switchboard/cmd_test_url.go
@@ -24,10 +24,13 @@ func runTest(cmd *cobra.Command, args []string) error {
 	}
 
 	rtr := createRouter(cfg)
-	browserName, profile, incognito, matched := rtr.FindMatch(url)
+	browserName, profile, incognito, matched, rewrittenURL := rtr.FindMatch(url)
 
 	if matched {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "URL: %s\n", url)
+		if rewrittenURL != url {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Rewritten URL: %s\n", rewrittenURL)
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Browser: %s\n", browserName)
 		if profile != "" {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Profile: %s\n", profile)

--- a/cmd/switchboard/cmd_validate.go
+++ b/cmd/switchboard/cmd_validate.go
@@ -23,6 +23,18 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Configuration is valid")
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Default browser: %s\n", cfg.DefaultBrowser)
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Rules: %d\n", len(cfg.Rules))
+
+	// Count rules with rewrites
+	rewriteCount := 0
+	for _, rule := range cfg.Rules {
+		if rule.Rewrite != "" {
+			rewriteCount++
+		}
+	}
+	if rewriteCount > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Rules with URL rewriting: %d\n", rewriteCount)
+	}
+
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Debug: %v\n", cfg.Debug)
 
 	// Show log file location

--- a/cmd/switchboard/main.go
+++ b/cmd/switchboard/main.go
@@ -34,7 +34,7 @@ type browserDetector interface {
 }
 
 type urlRouter interface {
-	FindMatch(url string) (browser, profile string, incognito, matched bool)
+	FindMatch(url string) (browser, profile string, incognito, matched bool, rewrittenURL string)
 }
 
 type browserLauncher interface {

--- a/cmd/switchboard/testhelpers_test.go
+++ b/cmd/switchboard/testhelpers_test.go
@@ -32,18 +32,23 @@ type fakeRouter struct {
 }
 
 type routeResult struct {
-	browser   string
-	profile   string
-	incognito bool
-	matched   bool
+	browser      string
+	profile      string
+	incognito    bool
+	matched      bool
+	rewrittenURL string
 }
 
-func (f *fakeRouter) FindMatch(url string) (browser, profile string, incognito, matched bool) {
+func (f *fakeRouter) FindMatch(url string) (browser, profile string, incognito, matched bool, rewrittenURL string) {
 	if result, ok := f.matches[url]; ok {
-		return result.browser, result.profile, result.incognito, result.matched
+		rewritten := result.rewrittenURL
+		if rewritten == "" {
+			rewritten = url
+		}
+		return result.browser, result.profile, result.incognito, result.matched, rewritten
 	}
 	// Default behavior
-	return "firefox", "", false, false
+	return "firefox", "", false, false, url
 }
 
 // fakeLauncher is a fake browser launcher for testing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Rule struct {
 	Browser   string   `yaml:"browser"`
 	Profile   string   `yaml:"profile,omitempty"`
 	Incognito bool     `yaml:"incognito,omitempty"`
+	Rewrite   string   `yaml:"rewrite,omitempty"`
 }
 
 // Load loads the configuration from the default config file location

--- a/internal/rewriter/rewriter.go
+++ b/internal/rewriter/rewriter.go
@@ -1,0 +1,71 @@
+package rewriter
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Rewrite rewrites a URL using a template string with substitution variables.
+// Supported variables:
+//   - {scheme}   - URL scheme (http, https, etc.)
+//   - {host}     - Hostname (e.g., "example.com")
+//   - {port}     - Port number (empty if not specified)
+//   - {path}     - Path portion (e.g., "/foo/bar")
+//   - {query}    - Query string (e.g., "key=value&key2=value2")
+//   - {fragment} - Fragment/hash (e.g., "section")
+//
+// Example:
+//   Rewrite("https://twitter.com/user/status/123", "xcancel.com{path}")
+//   Returns: "https://xcancel.com/user/status/123"
+func Rewrite(originalURL, template string) (string, error) {
+	if template == "" {
+		return originalURL, nil
+	}
+
+	// Ensure URL has a scheme for proper parsing
+	urlToParse := originalURL
+	if !strings.Contains(originalURL, "://") {
+		urlToParse = "https://" + originalURL
+	}
+
+	// Parse the original URL
+	parsed, err := url.Parse(urlToParse)
+	if err != nil {
+		return originalURL, err
+	}
+
+	// Extract URL components
+	scheme := parsed.Scheme
+	if scheme == "" {
+		scheme = "https" // Default to https if no scheme
+	}
+	host := parsed.Hostname()
+	port := parsed.Port()
+	path := parsed.Path
+	query := parsed.RawQuery
+	fragment := parsed.Fragment
+
+	// Build the new URL from the template
+	result := template
+
+	// Replace template variables
+	result = strings.ReplaceAll(result, "{scheme}", scheme)
+	result = strings.ReplaceAll(result, "{host}", host)
+	result = strings.ReplaceAll(result, "{port}", port)
+	result = strings.ReplaceAll(result, "{path}", path)
+	result = strings.ReplaceAll(result, "{query}", query)
+	result = strings.ReplaceAll(result, "{fragment}", fragment)
+
+	// If the result doesn't start with a scheme, prepend the original scheme
+	if !strings.Contains(result, "://") {
+		result = scheme + "://" + result
+	}
+
+	// Parse the result to ensure it's a valid URL and normalize it
+	finalURL, err := url.Parse(result)
+	if err != nil {
+		return originalURL, err
+	}
+
+	return finalURL.String(), nil
+}

--- a/internal/rewriter/rewriter_test.go
+++ b/internal/rewriter/rewriter_test.go
@@ -1,0 +1,165 @@
+package rewriter
+
+import (
+	"testing"
+)
+
+func TestRewrite(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "empty template returns original URL",
+			url:      "https://example.com/path",
+			template: "",
+			want:     "https://example.com/path",
+			wantErr:  false,
+		},
+		{
+			name:     "simple host replacement",
+			url:      "https://twitter.com/user/status/123",
+			template: "xcancel.com{path}",
+			want:     "https://xcancel.com/user/status/123",
+			wantErr:  false,
+		},
+		{
+			name:     "full URL with all components",
+			url:      "https://example.com:8080/path/to/page?key=value&key2=value2#section",
+			template: "newhost.com{path}?{query}#{fragment}",
+			want:     "https://newhost.com/path/to/page?key=value&key2=value2#section",
+			wantErr:  false,
+		},
+		{
+			name:     "preserve scheme",
+			url:      "http://example.com/path",
+			template: "newhost.com{path}",
+			want:     "http://newhost.com/path",
+			wantErr:  false,
+		},
+		{
+			name:     "use original host in template",
+			url:      "https://sub.example.com/path",
+			template: "archive.{host}{path}",
+			want:     "https://archive.sub.example.com/path",
+			wantErr:  false,
+		},
+		{
+			name:     "youtube to invidious",
+			url:      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			template: "invidious.io{path}?{query}",
+			want:     "https://invidious.io/watch?v=dQw4w9WgXcQ",
+			wantErr:  false,
+		},
+		{
+			name:     "reddit to teddit",
+			url:      "https://old.reddit.com/r/programming/comments/abc123/title",
+			template: "teddit.net{path}",
+			want:     "https://teddit.net/r/programming/comments/abc123/title",
+			wantErr:  false,
+		},
+		{
+			name:     "preserve query string only",
+			url:      "https://example.com/search?q=test&sort=date",
+			template: "searx.example.com/search?{query}",
+			want:     "https://searx.example.com/search?q=test&sort=date",
+			wantErr:  false,
+		},
+		{
+			name:     "path with trailing slash",
+			url:      "https://example.com/path/",
+			template: "newhost.com{path}",
+			want:     "https://newhost.com/path/",
+			wantErr:  false,
+		},
+		{
+			name:     "no path in original URL",
+			url:      "https://example.com",
+			template: "newhost.com{path}",
+			want:     "https://newhost.com",
+			wantErr:  false,
+		},
+		{
+			name:     "port in original URL",
+			url:      "https://example.com:3000/path",
+			template: "newhost.com:{port}{path}",
+			want:     "https://newhost.com:3000/path",
+			wantErr:  false,
+		},
+		{
+			name:     "fragment without query",
+			url:      "https://example.com/path#section",
+			template: "newhost.com{path}#{fragment}",
+			want:     "https://newhost.com/path#section",
+			wantErr:  false,
+		},
+		{
+			name:     "scheme in template",
+			url:      "https://example.com/path",
+			template: "{scheme}://newhost.com{path}",
+			want:     "https://newhost.com/path",
+			wantErr:  false,
+		},
+		{
+			name:     "complex rewrite with all variables",
+			url:      "https://old.example.com:8080/api/v1/users?limit=10&offset=20#results",
+			template: "{scheme}://new.{host}:{port}/v2{path}?{query}#{fragment}",
+			want:     "https://new.old.example.com:8080/v2/api/v1/users?limit=10&offset=20#results",
+			wantErr:  false,
+		},
+		{
+			name:     "URL without scheme gets https by default",
+			url:      "example.com/path",
+			template: "newhost.com{path}",
+			want:     "https://newhost.com/path",
+			wantErr:  false,
+		},
+		{
+			name:     "empty query and fragment get normalized",
+			url:      "https://example.com/path",
+			template: "newhost.com{path}?{query}#{fragment}",
+			want:     "https://newhost.com/path?",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Rewrite(tt.url, tt.template)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Rewrite() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Rewrite() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRewriteInvalidURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		template string
+	}{
+		{
+			name:     "invalid URL with spaces",
+			url:      "https://example.com/path with spaces",
+			template: "newhost.com{path}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Rewrite(tt.url, tt.template)
+			// Should return original URL when there's an error
+			if err != nil && got != tt.url {
+				t.Errorf("Rewrite() with invalid URL should return original URL, got %v", got)
+			}
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/nickygerritsen/switchboard/internal/config"
 	"github.com/nickygerritsen/switchboard/internal/logger"
 	"github.com/nickygerritsen/switchboard/internal/matcher"
+	"github.com/nickygerritsen/switchboard/internal/rewriter"
 )
 
 // Router handles URL routing based on configured rules
@@ -18,9 +19,9 @@ func NewRouter(cfg *config.Config) *Router {
 	}
 }
 
-// FindMatch finds the first matching rule for a URL and returns the browser name, profile, incognito flag, and whether a match was found
-// If no match is found, returns the default browser with empty profile, false for incognito, and false for matched
-func (r *Router) FindMatch(url string) (browser, profile string, incognito, matched bool) {
+// FindMatch finds the first matching rule for a URL and returns the browser name, profile, incognito flag, rewritten URL, and whether a match was found
+// If no match is found, returns the default browser with empty profile, false for incognito, original URL, and false for matched
+func (r *Router) FindMatch(url string) (browser, profile string, incognito, matched bool, rewrittenURL string) {
 	logger.Debug("Finding match for URL: %s", url)
 
 	// Try to match against each rule in order (first match wins)
@@ -28,14 +29,26 @@ func (r *Router) FindMatch(url string) (browser, profile string, incognito, matc
 		// Check each pattern in the rule
 		for _, pattern := range rule.Match {
 			if matcher.Match(pattern, url) {
+				// Apply URL rewriting if configured
+				finalURL := url
+				if rule.Rewrite != "" {
+					rewritten, err := rewriter.Rewrite(url, rule.Rewrite)
+					if err != nil {
+						logger.Warn("Failed to rewrite URL %s with template %s: %v", url, rule.Rewrite, err)
+					} else {
+						finalURL = rewritten
+						logger.Info("URL %s rewritten to %s", url, finalURL)
+					}
+				}
+
 				logger.Info("URL %s matched rule #%d (pattern: %s) -> browser: %s, profile: %s, incognito: %v",
 					url, i+1, pattern, rule.Browser, rule.Profile, rule.Incognito)
-				return rule.Browser, rule.Profile, rule.Incognito, true
+				return rule.Browser, rule.Profile, rule.Incognito, true, finalURL
 			}
 		}
 	}
 
 	// No match found, use default browser
 	logger.Info("URL %s did not match any rules, using default browser: %s", url, r.config.DefaultBrowser)
-	return r.config.DefaultBrowser, "", false, false
+	return r.config.DefaultBrowser, "", false, false, url
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -90,7 +90,7 @@ func TestRouter_FindMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			browser, profile, _, matched := router.FindMatch(tt.url)
+			browser, profile, _, matched, _ := router.FindMatch(tt.url)
 			if browser != tt.wantBrowser {
 				t.Errorf("FindMatch() browser = %q, want %q", browser, tt.wantBrowser)
 			}
@@ -118,7 +118,7 @@ func TestRouter_FindMatchInvalidURL(t *testing.T) {
 	router := NewRouter(cfg)
 
 	// Invalid URL should return default browser
-	browser, profile, _, matched := router.FindMatch("not a url")
+	browser, profile, _, matched, _ := router.FindMatch("not a url")
 	if browser != "chrome" {
 		t.Errorf("FindMatch() with invalid URL browser = %q, want %q", browser, "chrome")
 	}
@@ -193,7 +193,7 @@ rules:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			browser, profile, _, _ := router.FindMatch(tt.url)
+			browser, profile, _, _, _ := router.FindMatch(tt.url)
 			if browser != tt.wantBrowser {
 				t.Errorf("Route() browser = %q, want %q", browser, tt.wantBrowser)
 			}
@@ -212,7 +212,7 @@ func TestRouter_FindMatchEmptyRules(t *testing.T) {
 
 	router := NewRouter(cfg)
 
-	browser, profile, _, matched := router.FindMatch("https://google.com")
+	browser, profile, _, matched, _ := router.FindMatch("https://google.com")
 	if browser != "chrome" {
 		t.Errorf("FindMatch() with no rules browser = %q, want %q", browser, "chrome")
 	}
@@ -265,7 +265,7 @@ func TestRouter_FindMatchMultiplePatterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			browser, _, _, matched := router.FindMatch(tt.url)
+			browser, _, _, matched, _ := router.FindMatch(tt.url)
 			if browser != tt.wantBrowser {
 				t.Errorf("FindMatch() browser = %q, want %q", browser, tt.wantBrowser)
 			}
@@ -331,7 +331,7 @@ func TestRouter_FindMatchWithIncognito(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			browser, profile, incognito, matched := router.FindMatch(tt.url)
+			browser, profile, incognito, matched, _ := router.FindMatch(tt.url)
 			if browser != tt.wantBrowser {
 				t.Errorf("FindMatch() browser = %q, want %q", browser, tt.wantBrowser)
 			}
@@ -343,6 +343,90 @@ func TestRouter_FindMatchWithIncognito(t *testing.T) {
 			}
 			if matched != tt.wantMatched {
 				t.Errorf("FindMatch() matched = %v, want %v", matched, tt.wantMatched)
+			}
+		})
+	}
+}
+
+func TestRouter_FindMatchWithRewrite(t *testing.T) {
+	cfg := &config.Config{
+		DefaultBrowser: "chrome",
+		Rules: []config.Rule{
+			{
+				Match:   []string{"twitter.com/*", "x.com/*"},
+				Browser: "firefox",
+				Rewrite: "xcancel.com{path}",
+			},
+			{
+				Match:   []string{"*.youtube.com/*"},
+				Browser: "firefox",
+				Rewrite: "invidious.io{path}?{query}",
+			},
+			{
+				Match:   []string{"reddit.com/*", "*.reddit.com/*"},
+				Browser: "firefox",
+				Rewrite: "teddit.net{path}",
+			},
+		},
+	}
+
+	router := NewRouter(cfg)
+
+	tests := []struct {
+		name             string
+		url              string
+		wantBrowser      string
+		wantRewrittenURL string
+		wantMatched      bool
+	}{
+		{
+			name:             "rewrite twitter to xcancel",
+			url:              "https://twitter.com/user/status/123",
+			wantBrowser:      "firefox",
+			wantRewrittenURL: "https://xcancel.com/user/status/123",
+			wantMatched:      true,
+		},
+		{
+			name:             "rewrite x.com to xcancel",
+			url:              "https://x.com/user/status/456",
+			wantBrowser:      "firefox",
+			wantRewrittenURL: "https://xcancel.com/user/status/456",
+			wantMatched:      true,
+		},
+		{
+			name:             "rewrite youtube to invidious",
+			url:              "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			wantBrowser:      "firefox",
+			wantRewrittenURL: "https://invidious.io/watch?v=dQw4w9WgXcQ",
+			wantMatched:      true,
+		},
+		{
+			name:             "rewrite reddit to teddit",
+			url:              "https://old.reddit.com/r/programming/comments/abc/title",
+			wantBrowser:      "firefox",
+			wantRewrittenURL: "https://teddit.net/r/programming/comments/abc/title",
+			wantMatched:      true,
+		},
+		{
+			name:             "no match returns original URL",
+			url:              "https://example.com/path",
+			wantBrowser:      "chrome",
+			wantRewrittenURL: "https://example.com/path",
+			wantMatched:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			browser, _, _, matched, rewrittenURL := router.FindMatch(tt.url)
+			if browser != tt.wantBrowser {
+				t.Errorf("FindMatch() browser = %q, want %q", browser, tt.wantBrowser)
+			}
+			if matched != tt.wantMatched {
+				t.Errorf("FindMatch() matched = %v, want %v", matched, tt.wantMatched)
+			}
+			if rewrittenURL != tt.wantRewrittenURL {
+				t.Errorf("FindMatch() rewrittenURL = %q, want %q", rewrittenURL, tt.wantRewrittenURL)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implements URL rewriting feature (#9) that allows transforming URLs before opening them in browsers. This enables privacy-friendly redirects and alternative frontends.

## Changes

- **New `rewriter` package**: URL template substitution with variables:
  - `{scheme}` - URL scheme (http, https)
  - `{host}` - Hostname
  - `{port}` - Port number
  - `{path}` - Path portion
  - `{query}` - Query string
  - `{fragment}` - Fragment/hash

- **Updated config**: Added optional `rewrite` field to rules
- **Router enhancement**: Applies URL rewrites when rules match
- **CLI updates**: 
  - `open` command uses rewritten URLs
  - `test` command displays rewritten URLs
  - `validate` command shows count of rules with rewrites

## Example Configuration

```yaml
rules:
  - match:
      - "twitter.com/*"
      - "x.com/*"
    rewrite: "xcancel.com{path}"
    browser: firefox

  - match:
      - "*.youtube.com/*"
    rewrite: "invidious.io{path}?{query}"
    browser: firefox

  - match:
      - "reddit.com/*"
      - "*.reddit.com/*"
    rewrite: "teddit.net{path}"
    browser: firefox
```

## Test Results

✅ All tests passing
✅ Linter passes with 0 issues
✅ Manual testing verified:
  - `twitter.com/user/status/123` → `xcancel.com/user/status/123`
  - `youtube.com/watch?v=dQw4w9WgXcQ` → `invidious.io/watch?v=dQw4w9WgXcQ`
  - `old.reddit.com/r/programming` → `teddit.net/r/programming`
  - Non-matching URLs pass through unchanged

Resolves #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)