### PR TITLE
Add shell completion support for bash, zsh, and fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,47 @@ After registration, set Switchboard as your default browser:
 - **Linux**: Settings → Default Applications → Web Browser
 - **Windows**: Settings → Apps → Default apps → Web browser
 
+## Shell Completion
+
+Switchboard supports shell completion for bash, zsh, and fish. To enable completions:
+
+### Bash
+
+```bash
+# For current session only
+source <(switchboard completion bash)
+
+# For all sessions (Linux)
+switchboard completion bash > /etc/bash_completion.d/switchboard
+
+# For all sessions (macOS)
+switchboard completion bash > /usr/local/etc/bash_completion.d/switchboard
+```
+
+### Zsh
+
+```bash
+# Enable completions if not already enabled
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# For current session only
+source <(switchboard completion zsh)
+
+# For all sessions
+switchboard completion zsh > "${fpath[1]}/_switchboard"
+# Then start a new shell
+```
+
+### Fish
+
+```bash
+# For current session only
+switchboard completion fish | source
+
+# For all sessions
+switchboard completion fish > ~/.config/fish/completions/switchboard.fish
+```
+
 ## Configuration
 
 Switchboard looks for its configuration file at:
@@ -146,6 +187,9 @@ switchboard validate
 
 # Generate example configuration
 switchboard init
+
+# Generate shell completion scripts
+switchboard completion [bash|zsh|fish]
 ```
 
 ## License

--- a/claude.md
+++ b/claude.md
@@ -149,7 +149,7 @@ golangci-lint run
 go build ./...
 
 # Build the binary
-go build -o switchboard cmd/switchboard
+go build -o switchboard ./cmd/switchboard
 
 # Run the application
 ./switchboard open <url>

--- a/cmd/switchboard/cmd_completion.go
+++ b/cmd/switchboard/cmd_completion.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for switchboard.
+
+To load completions:
+
+Bash:
+
+  $ source <(switchboard completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ switchboard completion bash > /etc/bash_completion.d/switchboard
+  # macOS:
+  $ switchboard completion bash > /usr/local/etc/bash_completion.d/switchboard
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for current session only:
+  $ source <(switchboard completion zsh)
+
+  # To load completions for each session, execute once:
+  $ switchboard completion zsh > "${fpath[1]}/_switchboard"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  $ switchboard completion fish | source
+
+  # To load completions for each session, execute once:
+  $ switchboard completion fish > ~/.config/fish/completions/switchboard.fish
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE:                  runCompletion,
+}
+
+func runCompletion(cmd *cobra.Command, args []string) error {
+	switch args[0] {
+	case "bash":
+		return rootCmd.GenBashCompletion(cmd.OutOrStdout())
+	case "zsh":
+		return rootCmd.GenZshCompletion(cmd.OutOrStdout())
+	case "fish":
+		return rootCmd.GenFishCompletion(cmd.OutOrStdout(), true)
+	}
+	return nil
+}

--- a/cmd/switchboard/cmd_completion_test.go
+++ b/cmd/switchboard/cmd_completion_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunCompletion(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantErr      bool
+		wantContains string
+	}{
+		{
+			name:         "bash completion",
+			args:         []string{"bash"},
+			wantErr:      false,
+			wantContains: "# bash completion for switchboard",
+		},
+		{
+			name:         "zsh completion",
+			args:         []string{"zsh"},
+			wantErr:      false,
+			wantContains: "#compdef switchboard",
+		},
+		{
+			name:         "fish completion",
+			args:         []string{"fish"},
+			wantErr:      false,
+			wantContains: "# fish completion for switchboard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var outBuf bytes.Buffer
+			cmd := &cobra.Command{
+				Use:  completionCmd.Use,
+				RunE: completionCmd.RunE,
+			}
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&outBuf)
+
+			err := runCompletion(cmd, tt.args)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			output := outBuf.String()
+			if !strings.Contains(output, tt.wantContains) {
+				t.Errorf("Expected output to contain %q, but it didn't.\nOutput first 100 chars: %s", tt.wantContains, truncate(output, 100))
+			}
+		})
+	}
+}
+
+func TestCompletionCmdMetadata(t *testing.T) {
+	if completionCmd.Use != "completion [bash|zsh|fish]" {
+		t.Errorf("completionCmd.Use = %q, want %q", completionCmd.Use, "completion [bash|zsh|fish]")
+	}
+
+	if completionCmd.Short == "" {
+		t.Error("completionCmd.Short should not be empty")
+	}
+
+	if completionCmd.Long == "" {
+		t.Error("completionCmd.Long should not be empty")
+	}
+
+	if completionCmd.RunE == nil {
+		t.Error("completionCmd.RunE should not be nil")
+	}
+
+	// Check valid args - should contain bash, zsh, and fish
+	expectedValidArgs := map[string]bool{"bash": true, "zsh": true, "fish": true}
+	if len(completionCmd.ValidArgs) != len(expectedValidArgs) {
+		t.Errorf("completionCmd.ValidArgs length = %d, want %d", len(completionCmd.ValidArgs), len(expectedValidArgs))
+	}
+	for _, arg := range completionCmd.ValidArgs {
+		if !expectedValidArgs[arg] {
+			t.Errorf("Unexpected valid arg: %q", arg)
+		}
+	}
+	for arg := range expectedValidArgs {
+		found := false
+		for _, validArg := range completionCmd.ValidArgs {
+			if validArg == arg {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected valid arg %q not found in ValidArgs", arg)
+		}
+	}
+
+	// Check that help text contains key information
+	if !strings.Contains(completionCmd.Long, "bash") {
+		t.Error("Long help should mention bash")
+	}
+	if !strings.Contains(completionCmd.Long, "zsh") {
+		t.Error("Long help should mention zsh")
+	}
+	if !strings.Contains(completionCmd.Long, "fish") {
+		t.Error("Long help should mention fish")
+	}
+}
+
+// truncate returns the first n characters of s
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/cmd/switchboard/main.go
+++ b/cmd/switchboard/main.go
@@ -75,6 +75,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(registerCmd)
 	rootCmd.AddCommand(unregisterCmd)
+	rootCmd.AddCommand(completionCmd)
 }
 
 func main() {


### PR DESCRIPTION
Fixes #11

## Summary

Added shell completion support for bash, zsh, and fish using Cobra's built-in completion generators. Users can now generate completion scripts to enable command and flag completion in their preferred shell.

## Changes

- **New command**: `switchboard completion [bash|zsh|fish]`
- **Comprehensive tests**: Added tests for all three shell types and metadata validation
- **Documentation**: Updated README with installation instructions for each shell
- **Build fix**: Corrected build command in claude.md to use `./cmd/switchboard`

## Installation Examples

### Bash
```bash
# For current session
source <(switchboard completion bash)

# For all sessions (Linux)
switchboard completion bash > /etc/bash_completion.d/switchboard
```

### Zsh
```bash
# For current session
source <(switchboard completion zsh)

# For all sessions
switchboard completion zsh > "${fpath[1]}/_switchboard"
```

### Fish
```bash
# For current session
switchboard completion fish | source

# For all sessions
switchboard completion fish > ~/.config/fish/completions/switchboard.fish
```

## Test Plan

✅ All tests pass (`go test ./...`)
✅ Linter passes (`golangci-lint run`)
✅ Bash completion script generates correctly
✅ Zsh completion script generates correctly
✅ Fish completion script generates correctly
✅ Command metadata tests verify expected behavior