### PR TITLE
Add automated releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,79 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - id: switchboard
+    binary: switchboard
+    main: ./cmd/switchboard
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: switchboard
+    formats: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: zip
+    files:
+      - README.md
+      - LICENSE
+      - config.example.yaml
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - typo
+  groups:
+    - title: "New Features"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "Enhancements"
+      regexp: '^.*?(refactor|perf|improve)(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: "Documentation"
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: "Other Changes"
+      order: 999
+
+release:
+  github:
+    owner: nickygerritsen
+    name: switchboard
+  name_template: "v{{.Version}}"
+  prerelease: auto
+  draft: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,38 @@ A smart URL router that opens links in different browsers based on configurable 
 
 ## Installation
 
-### Building from source
+### Download Pre-built Binaries
+
+Download the latest release for your platform from the [releases page](https://github.com/nickygerritsen/switchboard/releases).
+
+**macOS:**
+```bash
+# Download and extract (replace VERSION and ARCH with actual values)
+curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Darwin_ARCH.tar.gz | tar xz
+
+# Move to a directory in your PATH
+sudo mv switchboard /usr/local/bin/
+
+# Verify installation
+switchboard --version
+```
+
+**Linux:**
+```bash
+# Download and extract (replace VERSION and ARCH with actual values)
+curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Linux_ARCH.tar.gz | tar xz
+
+# Move to a directory in your PATH
+sudo mv switchboard /usr/local/bin/
+
+# Verify installation
+switchboard --version
+```
+
+**Windows:**
+Download the `.zip` file for your architecture from the releases page, extract it, and add the directory to your PATH.
+
+### Building from Source
 
 ```bash
 go build -o switchboard ./cmd/switchboard

--- a/cmd/switchboard/main.go
+++ b/cmd/switchboard/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.1.0"
+const version = "dev"
 
 var (
 	cfgFile string


### PR DESCRIPTION
Fixes #12

## Summary

Set up automated releases with pre-built binaries for major platforms using GitHub Actions and GoReleaser. Users can now download pre-built binaries instead of having to build from source.

## Changes

- **GoReleaser configuration** (`.goreleaser.yml`)
  - Builds for macOS (amd64/arm64), Linux (amd64/arm64), Windows (amd64/arm64)
  - Creates tar.gz archives (zip for Windows)
  - Generates checksums for verification
  - Auto-generates changelog from commits
  
- **GitHub Actions workflow** (`.github/workflows/release.yml`)
  - Triggered on version tags (e.g., `v1.0.0`)
  - Runs tests before building
  - Uses GoReleaser to build and publish releases
  
- **Version management**
  - Changed version from "0.1.0" to "dev" in source
  - GoReleaser replaces with actual version at build time via ldflags
  
- **Installation documentation**
  - Added instructions for downloading pre-built binaries
  - Includes examples for macOS, Linux, and Windows

## Supported Platforms

- macOS (Intel x86_64 and Apple Silicon arm64)
- Linux (amd64 and arm64)
- Windows (amd64 and arm64)

## How to Release

1. Create and push a version tag:
   ```bash
   git tag v1.0.0
   git push origin v1.0.0
   ```
2. GitHub Actions will automatically:
   - Run tests
   - Build binaries for all platforms
   - Create archives and checksums
   - Publish a GitHub release with changelog

## Test Plan

✅ All tests pass (`go test ./...`)
✅ Linter passes (`golangci-lint run`)
✅ GoReleaser configuration validated (`goreleaser check`)