### PR TITLE
fix: version injection in releases and add Conventional Commits

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -44,14 +44,38 @@ The main branch is `main`.
 
 ## Commit Message Format
 
-All commits should include co-authorship with Claude:
+We use [Conventional Commits](https://www.conventionalcommits.org/) format for better changelog generation:
 
 ```
-Your commit message here
+<type>: <description>
+
+[optional body]
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Commit Types
+
+- **feat**: New feature (appears in changelog under "New Features")
+- **fix**: Bug fix (appears in changelog under "Bug Fixes")
+- **docs**: Documentation changes (appears in changelog under "Documentation")
+- **refactor**: Code refactoring without behavior change (appears in changelog under "Enhancements")
+- **perf**: Performance improvements (appears in changelog under "Enhancements")
+- **test**: Adding or updating tests (excluded from changelog)
+- **chore**: Maintenance tasks (excluded from changelog)
+
+### Examples
+
+```
+feat: add shell completion support for bash, zsh, and fish
+
+fix: resolve Safari incognito warning not being logged
+
+docs: update README with installation instructions
+
+refactor: simplify router matching logic
 ```
 
 Keep commit messages concise and descriptive.

--- a/cmd/switchboard/main.go
+++ b/cmd/switchboard/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "dev"
+var version = "dev"
 
 var (
 	cfgFile string


### PR DESCRIPTION
Fixes two issues from the v1.0.0 release:

## 1. Version Injection in Releases

**Problem**: Built binaries show "dev" instead of the actual version (e.g., "v1.0.0")

**Root cause**: The `version` variable was declared as `const` instead of `var`, which prevents GoReleaser's `-X` ldflags from overriding it.

**Solution**:
- Changed `const version = "dev"` to `var version = "dev"` in main.go
- Simplified ldflags from full package path to `main.version`
- Tested locally with `go build -ldflags "-X 'main.version=v1.0.0-test'"` ✅

## 2. Conventional Commits Format

**Problem**: All commits in v1.0.0 changelog appeared under "Other Changes" because they didn't match the expected format.

**Solution**: Added Conventional Commits documentation to `claude.md`:
- Documented commit message format: `<type>: <description>`
- Listed all commit types (feat, fix, docs, refactor, perf, test, chore)
- Added examples for each type
- Explained how types map to changelog categories

## Changes

- `cmd/switchboard/main.go`: Changed `const version` to `var version`
- `.goreleaser.yml`: Fixed ldflags to use `main.version`
- `claude.md`: Added Conventional Commits format documentation

## Test Plan

✅ All tests pass (`go test ./...`)
✅ Linter passes (`golangci-lint run`)
✅ Version injection tested locally and works correctly
✅ GoReleaser config validated (`goreleaser check`)

## Next Steps

After merging, we should:
1. Delete the v1.0.0 tag and release
2. Re-create v1.0.0 with these fixes
3. Future commits will use Conventional Commits format for better changelogs