### PR TITLE
fix: use GitHub username instead of email in changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,8 @@ checksum:
 changelog:
   use: github
   sort: asc
+  abbrev: 0
+  format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
   filters:
     exclude:
       - "^docs:"


### PR DESCRIPTION
## Summary

Updated the changelog format to display GitHub usernames instead of email addresses for better privacy.

## Changes

- Added custom `format` field to changelog configuration
- Format: `{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})`

## Example Output

**Before:**
```
c8ec7eb: fix: version injection in releases and add Conventional Commits (Your Name <your@email.com>)
```

**After:**
```
c8ec7eb: fix: version injection in releases and add Conventional Commits (@nickygerritsen)
```

## Test Plan

✅ GoReleaser config validated (`goreleaser check`)
✅ All tests pass
✅ Linter passes

After merging, future releases will show GitHub usernames instead of email addresses in the changelog.