### PR TITLE
feat: add installation scripts for easy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ A smart URL router that opens links in different browsers based on configurable 
 
 ## Installation
 
+### Quick Install (Recommended)
+
+**macOS and Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh
+```
+
+Or with wget:
+```bash
+wget -qO- https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps1 | iex
+```
+
+**Options:**
+- Install specific version: `curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh -s -- --version=v1.0.0`
+- Auto-register as browser: `curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh -s -- --register`
+- Windows with options: `irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps1 | iex -ArgumentList "-Version v1.0.0 -Register"`
+
 ### Download Pre-built Binaries
 
 Download the latest release for your platform from the [releases page](https://github.com/nickygerritsen/switchboard/releases).

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,254 @@
+# Switchboard Installation Script for Windows
+# Requires PowerShell 5.1 or later
+
+param(
+    [string]$Version = "",
+    [switch]$Register = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+# Configuration
+$Repo = "nickygerritsen/switchboard"
+$BinaryName = "switchboard.exe"
+$InstallDir = "$env:LOCALAPPDATA\switchboard"
+
+# Print colored output
+function Write-Info {
+    param([string]$Message)
+    Write-Host "==> " -ForegroundColor Green -NoNewline
+    Write-Host $Message
+}
+
+function Write-Error {
+    param([string]$Message)
+    Write-Host "Error: " -ForegroundColor Red -NoNewline
+    Write-Host $Message
+}
+
+function Write-Warning {
+    param([string]$Message)
+    Write-Host "Warning: " -ForegroundColor Yellow -NoNewline
+    Write-Host $Message
+}
+
+# Detect architecture
+function Get-Architecture {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "x86_64" }
+        "ARM64" { return "arm64" }
+        default {
+            Write-Error "Unsupported architecture: $arch"
+            Write-Error "Switchboard supports x86_64 and arm64 only."
+            exit 1
+        }
+    }
+}
+
+# Get latest version from GitHub
+function Get-LatestVersion {
+    Write-Info "Fetching latest version..."
+
+    try {
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+        return $response.tag_name
+    }
+    catch {
+        Write-Error "Failed to fetch latest version: $_"
+        exit 1
+    }
+}
+
+# Download file
+function Download-File {
+    param(
+        [string]$Url,
+        [string]$Output
+    )
+
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $Output -UseBasicParsing
+    }
+    catch {
+        Write-Error "Failed to download from $Url : $_"
+        exit 1
+    }
+}
+
+# Verify checksum
+function Test-Checksum {
+    param(
+        [string]$FilePath,
+        [string]$ChecksumsFile
+    )
+
+    Write-Info "Verifying checksum..."
+
+    # Read checksums file
+    $checksums = Get-Content $ChecksumsFile
+    $fileName = Split-Path -Leaf $FilePath
+
+    # Find expected checksum
+    $checksumLine = $checksums | Where-Object { $_ -match [regex]::Escape($fileName) }
+
+    if (-not $checksumLine) {
+        Write-Warning "Could not find checksum for $fileName"
+        return $false
+    }
+
+    $expectedChecksum = ($checksumLine -split '\s+')[0]
+
+    # Calculate actual checksum
+    $actualChecksum = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLower()
+
+    if ($expectedChecksum -eq $actualChecksum) {
+        Write-Info "Checksum verified successfully"
+        return $true
+    }
+    else {
+        Write-Error "Checksum verification failed!"
+        Write-Error "Expected: $expectedChecksum"
+        Write-Error "Got:      $actualChecksum"
+        return $false
+    }
+}
+
+# Check if directory is in PATH
+function Test-InPath {
+    param([string]$Directory)
+
+    $pathDirs = $env:PATH -split ';'
+    return $pathDirs -contains $Directory
+}
+
+# Add directory to PATH
+function Add-ToPath {
+    param([string]$Directory)
+
+    Write-Info "Adding $Directory to user PATH..."
+
+    # Get current user PATH
+    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+
+    # Add directory if not already present
+    if ($userPath -notlike "*$Directory*") {
+        $newPath = "$userPath;$Directory"
+        [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+
+        # Update current session PATH
+        $env:PATH = "$env:PATH;$Directory"
+
+        Write-Info "Added to PATH. You may need to restart your terminal."
+        return $true
+    }
+
+    return $false
+}
+
+# Main installation
+function Main {
+    Write-Info "Installing Switchboard..."
+
+    # Detect system
+    $arch = Get-Architecture
+    $os = "Windows"
+
+    Write-Info "Detected OS: $os"
+    Write-Info "Detected Architecture: $arch"
+
+    # Get version if not specified
+    if (-not $Version) {
+        $Version = Get-LatestVersion
+    }
+
+    Write-Info "Installing version: $Version"
+
+    # Build download URLs
+    $versionNoV = $Version -replace '^v', ''
+    $archiveName = "${BinaryName.Replace('.exe', '')}_${versionNoV}_${os}_${arch}.zip"
+    $downloadUrl = "https://github.com/$Repo/releases/download/$Version/$archiveName"
+    $checksumsUrl = "https://github.com/$Repo/releases/download/$Version/checksums.txt"
+
+    # Create temporary directory
+    $tmpDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName()))
+
+    try {
+        # Download archive and checksums
+        Write-Info "Downloading $archiveName..."
+        $archivePath = Join-Path $tmpDir $archiveName
+        Download-File -Url $downloadUrl -Output $archivePath
+
+        Write-Info "Downloading checksums..."
+        $checksumsPath = Join-Path $tmpDir "checksums.txt"
+        Download-File -Url $checksumsUrl -Output $checksumsPath
+
+        # Verify checksum
+        if (-not (Test-Checksum -FilePath $archivePath -ChecksumsFile $checksumsPath)) {
+            Write-Error "Installation aborted due to checksum verification failure"
+            exit 1
+        }
+
+        # Extract archive
+        Write-Info "Extracting archive..."
+        Expand-Archive -Path $archivePath -DestinationPath $tmpDir -Force
+
+        # Create installation directory
+        if (-not (Test-Path $InstallDir)) {
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+        }
+
+        # Install binary
+        Write-Info "Installing to $InstallDir..."
+        $sourcePath = Join-Path $tmpDir $BinaryName
+        $targetPath = Join-Path $InstallDir $BinaryName
+
+        Copy-Item -Path $sourcePath -Destination $targetPath -Force
+
+        # Add to PATH if not already
+        if (-not (Test-InPath -Directory $InstallDir)) {
+            Add-ToPath -Directory $InstallDir
+        }
+
+        # Verify installation
+        Write-Info "Installation successful!"
+        Write-Info "Installed: $targetPath"
+
+        # Show version
+        try {
+            $installedVersion = & $targetPath --version 2>&1 | Select-Object -First 1
+            Write-Info "Version: $installedVersion"
+        }
+        catch {
+            Write-Warning "Could not verify installed version"
+        }
+
+        # Optionally register as default browser
+        if ($Register) {
+            Write-Info "Registering Switchboard as a browser..."
+            try {
+                & $targetPath register
+                Write-Info "Registration successful!"
+                Write-Info "You can now set Switchboard as your default browser in Windows Settings"
+            }
+            catch {
+                Write-Warning "Registration failed. You can register manually later with: switchboard register"
+            }
+        }
+        else {
+            Write-Host ""
+            Write-Info "To register Switchboard as a browser, run: switchboard register"
+            Write-Info "Then set it as your default browser in Windows Settings"
+        }
+
+        Write-Host ""
+        Write-Info "Installation complete!"
+    }
+    finally {
+        # Cleanup
+        Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Run main function
+Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,269 @@
+#!/bin/sh
+set -e
+
+# Switchboard Installation Script
+# Install the latest version of Switchboard from GitHub releases
+
+REPO="nickygerritsen/switchboard"
+INSTALL_DIR="/usr/local/bin"
+USER_INSTALL_DIR="$HOME/.local/bin"
+BINARY_NAME="switchboard"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_info() {
+    printf "${GREEN}==>${NC} %s\n" "$1"
+}
+
+print_error() {
+    printf "${RED}Error:${NC} %s\n" "$1" >&2
+}
+
+print_warning() {
+    printf "${YELLOW}Warning:${NC} %s\n" "$1"
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*)
+            echo "Darwin"
+            ;;
+        Linux*)
+            echo "Linux"
+            ;;
+        *)
+            print_error "Unsupported operating system: $(uname -s)"
+            print_error "This script supports macOS and Linux only."
+            print_error "For Windows, use install.ps1 instead."
+            exit 1
+            ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)
+            echo "x86_64"
+            ;;
+        aarch64|arm64)
+            echo "arm64"
+            ;;
+        *)
+            print_error "Unsupported architecture: $(uname -m)"
+            print_error "Switchboard supports x86_64 and arm64 only."
+            exit 1
+            ;;
+    esac
+}
+
+# Get latest version from GitHub
+get_latest_version() {
+    print_info "Fetching latest version..."
+
+    if command -v curl >/dev/null 2>&1; then
+        VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    elif command -v wget >/dev/null 2>&1; then
+        VERSION=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    else
+        print_error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+
+    if [ -z "$VERSION" ]; then
+        print_error "Failed to fetch latest version"
+        exit 1
+    fi
+
+    echo "$VERSION"
+}
+
+# Download file
+download_file() {
+    url="$1"
+    output="$2"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$output"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$output" "$url"
+    else
+        print_error "Neither curl nor wget found"
+        exit 1
+    fi
+}
+
+# Verify checksum
+verify_checksum() {
+    archive_file="$1"
+    checksums_file="$2"
+
+    print_info "Verifying checksum..."
+
+    # Extract expected checksum for our file
+    expected_checksum=$(grep "$(basename "$archive_file")" "$checksums_file" | awk '{print $1}')
+
+    if [ -z "$expected_checksum" ]; then
+        print_warning "Could not find checksum for $(basename "$archive_file")"
+        return 1
+    fi
+
+    # Calculate actual checksum
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_checksum=$(sha256sum "$archive_file" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual_checksum=$(shasum -a 256 "$archive_file" | awk '{print $1}')
+    else
+        print_warning "Neither sha256sum nor shasum found, skipping checksum verification"
+        return 0
+    fi
+
+    if [ "$expected_checksum" = "$actual_checksum" ]; then
+        print_info "Checksum verified successfully"
+        return 0
+    else
+        print_error "Checksum verification failed!"
+        print_error "Expected: $expected_checksum"
+        print_error "Got:      $actual_checksum"
+        return 1
+    fi
+}
+
+# Main installation
+main() {
+    print_info "Installing Switchboard..."
+
+    # Parse command line arguments
+    VERSION=""
+    REGISTER=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version=*)
+                VERSION="${1#*=}"
+                shift
+                ;;
+            --register)
+                REGISTER=1
+                shift
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                echo "Usage: $0 [--version=VERSION] [--register]"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Detect system
+    OS=$(detect_os)
+    ARCH=$(detect_arch)
+
+    print_info "Detected OS: $OS"
+    print_info "Detected Architecture: $ARCH"
+
+    # Get version if not specified
+    if [ -z "$VERSION" ]; then
+        VERSION=$(get_latest_version)
+    fi
+
+    print_info "Installing version: $VERSION"
+
+    # Build download URLs
+    ARCHIVE_NAME="${BINARY_NAME}_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE_NAME"
+    CHECKSUMS_URL="https://github.com/$REPO/releases/download/$VERSION/checksums.txt"
+
+    # Create temporary directory
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    # Download archive and checksums
+    print_info "Downloading $ARCHIVE_NAME..."
+    download_file "$DOWNLOAD_URL" "$TMP_DIR/$ARCHIVE_NAME"
+
+    print_info "Downloading checksums..."
+    download_file "$CHECKSUMS_URL" "$TMP_DIR/checksums.txt"
+
+    # Verify checksum
+    if ! verify_checksum "$TMP_DIR/$ARCHIVE_NAME" "$TMP_DIR/checksums.txt"; then
+        print_error "Installation aborted due to checksum verification failure"
+        exit 1
+    fi
+
+    # Extract archive
+    print_info "Extracting archive..."
+    tar -xzf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"
+
+    # Determine installation directory
+    if [ -w "$INSTALL_DIR" ] || [ "$(id -u)" = "0" ]; then
+        TARGET_DIR="$INSTALL_DIR"
+        USE_SUDO=""
+    else
+        # Check if we can use sudo
+        if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            TARGET_DIR="$INSTALL_DIR"
+            USE_SUDO="sudo"
+        else
+            print_warning "$INSTALL_DIR is not writable and sudo is not available"
+            print_info "Installing to $USER_INSTALL_DIR instead"
+            TARGET_DIR="$USER_INSTALL_DIR"
+            USE_SUDO=""
+
+            # Create user install directory if it doesn't exist
+            mkdir -p "$TARGET_DIR"
+        fi
+    fi
+
+    # Install binary
+    print_info "Installing to $TARGET_DIR..."
+    if [ -n "$USE_SUDO" ]; then
+        sudo install -m 755 "$TMP_DIR/$BINARY_NAME" "$TARGET_DIR/$BINARY_NAME"
+    else
+        install -m 755 "$TMP_DIR/$BINARY_NAME" "$TARGET_DIR/$BINARY_NAME"
+    fi
+
+    # Verify installation
+    if ! command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        print_warning "$BINARY_NAME installed but not found in PATH"
+
+        if [ "$TARGET_DIR" = "$USER_INSTALL_DIR" ]; then
+            print_warning "You may need to add $USER_INSTALL_DIR to your PATH"
+            print_info "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+            print_info "  export PATH=\"\$PATH:$USER_INSTALL_DIR\""
+        fi
+    else
+        print_info "Installation successful!"
+        print_info "Installed: $TARGET_DIR/$BINARY_NAME"
+
+        # Show version
+        INSTALLED_VERSION=$("$BINARY_NAME" --version 2>&1 | head -n1)
+        print_info "Version: $INSTALLED_VERSION"
+    fi
+
+    # Optionally register as default browser
+    if [ $REGISTER -eq 1 ]; then
+        print_info "Registering Switchboard as a browser..."
+        if "$BINARY_NAME" register; then
+            print_info "Registration successful!"
+            print_info "You can now set Switchboard as your default browser in system settings"
+        else
+            print_warning "Registration failed. You can register manually later with: switchboard register"
+        fi
+    else
+        print_info ""
+        print_info "To register Switchboard as a browser, run: switchboard register"
+        print_info "Then set it as your default browser in system settings"
+    fi
+
+    print_info ""
+    print_info "Installation complete!"
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION
## Summary

Adds one-line installation scripts for easy setup across all platforms.

## Changes

- ✅ **install.sh** - POSIX-compliant shell script for Unix/Linux/macOS
  - Automatic OS and architecture detection (x86_64, ARM64)
  - Downloads latest release from GitHub releases
  - Verifies SHA256 checksums for security
  - Installs to `/usr/local/bin` (with sudo) or `~/.local/bin` (without sudo)
  - Supports `--version` option to install specific version
  - Supports `--register` option to auto-register as default browser
  - Helpful error messages and colored output

- ✅ **install.ps1** - PowerShell script for Windows
  - Architecture detection (x86_64, ARM64)
  - Downloads and verifies checksums
  - Installs to `$env:LOCALAPPDATA\switchboard`
  - Automatically adds to user PATH
  - Supports `-Version` parameter for specific versions
  - Supports `-Register` switch for auto-registration

- ✅ **Updated README.md** with quick install instructions

## Usage

**macOS/Linux:**
```bash
curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh
```

**Windows:**
```powershell
irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps1 | iex
```

## Testing

- ✅ Shell script syntax validated with `sh -n`
- ✅ Scripts follow best practices for security (checksum verification)
- ✅ Error handling and helpful user messages included

Resolves #13