### PR TITLE
fix: redirect print functions to stderr in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ NC='\033[0m' # No Color
 
 # Print colored output
 print_info() {
-    printf "${GREEN}==>${NC} %s\n" "$1"
+    printf "${GREEN}==>${NC} %s\n" "$1" >&2
 }
 
 print_error() {
@@ -25,7 +25,7 @@ print_error() {
 }
 
 print_warning() {
-    printf "${YELLOW}Warning:${NC} %s\n" "$1"
+    printf "${YELLOW}Warning:${NC} %s\n" "$1" >&2
 }
 
 # Detect OS


### PR DESCRIPTION
## Issue

The installation script was broken because `print_info()` and `print_warning()` were writing to stdout, which was interfering with command substitution.

When running:
```bash
VERSION=$(get_latest_version)
```

The captured output included both the "Fetching latest version..." message and the actual version, resulting in:
```
VERSION="==> Fetching latest version...
v1.0.0"
```

This caused the download URL to be malformed.

## Fix

All print functions (`print_info`, `print_error`, `print_warning`) now write to stderr (`>&2`) instead of stdout. This ensures they don't interfere with command substitution while still displaying messages to the user.

## Testing

- ✅ Shell script syntax validated with `sh -n`
- ✅ Function outputs are now properly separated (stdout for data, stderr for messages)