### PR TITLE
docs: reorganize installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,37 +39,6 @@ irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps
 - Auto-register as browser: `curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh -s -- --register`
 - Windows with options: `irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps1 | iex -ArgumentList "-Version v1.0.0 -Register"`
 
-### Download Pre-built Binaries
-
-Download the latest release for your platform from the [releases page](https://github.com/nickygerritsen/switchboard/releases).
-
-**macOS:**
-```bash
-# Download and extract (replace VERSION and ARCH with actual values)
-curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Darwin_ARCH.tar.gz | tar xz
-
-# Move to a directory in your PATH
-sudo mv switchboard /usr/local/bin/
-
-# Verify installation
-switchboard --version
-```
-
-**Linux:**
-```bash
-# Download and extract (replace VERSION and ARCH with actual values)
-curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Linux_ARCH.tar.gz | tar xz
-
-# Move to a directory in your PATH
-sudo mv switchboard /usr/local/bin/
-
-# Verify installation
-switchboard --version
-```
-
-**Windows:**
-Download the `.zip` file for your architecture from the releases page, extract it, and add the directory to your PATH.
-
 ### Building from Source
 
 ```bash
@@ -244,6 +213,39 @@ switchboard init
 # Generate shell completion scripts
 switchboard completion [bash|zsh|fish]
 ```
+
+## Alternative: Manual Installation
+
+If you prefer not to use the installation script, you can manually download and install pre-built binaries.
+
+Download the latest release for your platform from the [releases page](https://github.com/nickygerritsen/switchboard/releases).
+
+**macOS:**
+```bash
+# Download and extract (replace VERSION and ARCH with actual values)
+curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Darwin_ARCH.tar.gz | tar xz
+
+# Move to a directory in your PATH
+sudo mv switchboard /usr/local/bin/
+
+# Verify installation
+switchboard --version
+```
+
+**Linux:**
+```bash
+# Download and extract (replace VERSION and ARCH with actual values)
+curl -L https://github.com/nickygerritsen/switchboard/releases/download/vVERSION/switchboard_VERSION_Linux_ARCH.tar.gz | tar xz
+
+# Move to a directory in your PATH
+sudo mv switchboard /usr/local/bin/
+
+# Verify installation
+switchboard --version
+```
+
+**Windows:**
+Download the `.zip` file for your architecture from the releases page, extract it, and add the directory to your PATH.
 
 ## License
 


### PR DESCRIPTION
## Summary

Reorganizes the installation section of the README to prioritize the quick install script while keeping manual installation as an alternative.

## Changes

**Before:**
1. Quick Install (Recommended)
2. Download Pre-built Binaries
3. Building from Source
4. Register as a browser

**After:**
1. Quick Install (Recommended)
2. Building from Source
3. Register as a browser
4. ...rest of documentation...
5. Alternative: Manual Installation (at the end)

## Rationale

- The quick install script is now the recommended and easiest method
- Manual installation is still available for users who:
  - Don't want to pipe curl to sh for security reasons
  - Work in restricted corporate environments
  - Prefer offline installation
  - Want more control over the process
- Moving manual installation to the end reduces redundancy and keeps the README focused on the recommended approach