### PR TITLE
feat: add Homebrew support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,20 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-formula:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          formula: switchboard
+          tap: nickygerritsen/homebrew-tap

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps
 - Auto-register as browser: `curl -fsSL https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.sh | sh -s -- --register`
 - Windows with options: `irm https://raw.githubusercontent.com/nickygerritsen/switchboard/main/install.ps1 | iex -ArgumentList "-Version v1.0.0 -Register"`
 
+### Homebrew (macOS and Linux)
+
+```bash
+brew install nickygerritsen/tap/switchboard
+```
+
+After installation, run `switchboard register` to make it available as a browser in your system settings.
+
 ### Building from Source
 
 ```bash


### PR DESCRIPTION
## Summary

Adds Homebrew tap support for easy installation on macOS and Linux.

## Changes

### Created Homebrew Tap Repository
- ✅ Created `nickygerritsen/homebrew-tap` repository
- ✅ Added `Formula/switchboard.rb` with proper formula structure
- ✅ Formula builds from source using Go
- ✅ Includes version injection via ldflags
- ✅ Post-install caveats for browser registration

### Automated Formula Updates
- ✅ Added GitHub Action workflow (`.github/workflows/update-homebrew.yml`)
- ✅ Automatically updates formula when new releases are published
- ✅ Uses `HOMEBREW_TAP_TOKEN` secret for authentication

### Updated Documentation
- ✅ Added Homebrew installation section to README
- ✅ Placed between "Quick Install" and "Building from Source"

## Installation

Users can now install Switchboard with:
```bash
brew install nickygerritsen/tap/switchboard
```

## How It Works

1. User tags a new version in switchboard repo
2. GitHub Actions creates release
3. Update Homebrew workflow triggers automatically
4. Formula in homebrew-tap is updated with new version and SHA256
5. Users can `brew upgrade switchboard` to get the latest version

## Testing

- ✅ Formula syntax validated
- ✅ Successfully pushed to homebrew-tap repository
- ✅ Workflow file syntax is correct

Resolves #14