### PR TITLE
fix: use workflow_run trigger for Homebrew updates

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,8 +1,10 @@
 name: Update Homebrew Formula
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -11,6 +13,7 @@ jobs:
   update-formula:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3


### PR DESCRIPTION
## Problem

The Homebrew formula update workflow wasn't triggering because GitHub prevents workflows from running on events caused by other workflows when using `GITHUB_TOKEN` (to prevent infinite recursion).

Since our Release workflow creates releases using `GITHUB_TOKEN`, the `release: published` trigger never fires for the Update Homebrew Formula workflow.

## Solution

Changed to use `workflow_run` trigger instead:
- Triggers after the Release workflow completes
- Only runs if the Release workflow was successful
- Bypasses the `GITHUB_TOKEN` limitation

## Changes

```yaml
# Before:
on:
  release:
    types: [published]

# After:
on:
  workflow_run:
    workflows: ["Release"]
    types:
      - completed
```

Added condition to only run on successful Release workflow:
```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

## Testing

After this is merged, the next release (or re-release of v1.0.1) should automatically trigger the Homebrew formula update.

## References

- [GitHub Docs: Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)