### PR TITLE
fix: pass tag and revision to Homebrew bump action

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -15,9 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: release } = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            return release.tag_name;
+          result-encoding: string
+
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           formula: switchboard
           tap: nickygerritsen/homebrew-tap
+          tag: ${{ steps.get_release.outputs.result }}
+          revision: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Problem

The Homebrew bump action was failing with:
```
Error: Invalid usage: switchboard: no `--url` or `--version` argument specified!
```

This happened because when using `workflow_run` trigger, the action doesn't have access to the release event context (like `github.ref` and `github.sha`) that it normally uses to extract version information.

## Solution

Added explicit version information retrieval:

1. **Get latest release**: Use `actions/github-script` to fetch the latest release and extract the tag name
2. **Pass tag explicitly**: Provide `tag` parameter to the bump action
3. **Pass revision explicitly**: Use `github.event.workflow_run.head_sha` for the commit revision

## Changes

```yaml
- name: Get latest release
  id: get_release
  uses: actions/github-script@v7
  with:
    script: |
      const { data: release } = await github.rest.repos.getLatestRelease({
        owner: context.repo.owner,
        repo: context.repo.repo
      });
      return release.tag_name;
    result-encoding: string

- name: Update Homebrew formula
  uses: dawidd6/action-homebrew-bump-formula@v3
  with:
    token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
    formula: switchboard
    tap: nickygerritsen/homebrew-tap
    tag: ${{ steps.get_release.outputs.result }}
    revision: ${{ github.event.workflow_run.head_sha }}
```

## Testing

After merge, the next release (or re-tag of v1.0.1) should successfully update the Homebrew formula.