### PR TITLE
fix: disable forking for Homebrew formula updates

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -35,3 +35,4 @@ jobs:
           tap: nickygerritsen/homebrew-tap
           tag: ${{ steps.get_release.outputs.result }}
           revision: ${{ github.event.workflow_run.head_sha }}
+          no_fork: true


### PR DESCRIPTION
## Problem

The Homebrew bump action was failing with:
```
Error: Unable to fork: GitHub API Error: Resource not accessible by personal access token
```

The action was trying to fork the `homebrew-tap` repository and create a pull request, but we own this repository and can push directly to it.

## Solution

Added `no_fork: true` parameter to the action configuration. This tells the action to:
- Push changes directly to the tap repository
- Skip the forking and PR creation process
- Commit directly to the main branch

## Changes

```yaml
- name: Update Homebrew formula
  uses: dawidd6/action-homebrew-bump-formula@v3
  with:
    token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
    formula: switchboard
    tap: nickygerritsen/homebrew-tap
    tag: ${{ steps.get_release.outputs.result }}
    revision: ${{ github.event.workflow_run.head_sha }}
    no_fork: true  # ← Added this
```

## Benefits

- Simpler workflow - no PR needed for our own tap
- Faster updates - changes are immediate
- No forking permissions required

## Testing

After merge, re-tagging v1.0.1 should successfully update the Homebrew formula with a direct commit to the tap repository.