### PR TITLE
fix: prevent symlink resolution for macOS handler path

### DIFF
--- a/internal/registration/registration.go
+++ b/internal/registration/registration.go
@@ -3,7 +3,6 @@ package registration
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 // Registrar handles browser registration for the current platform
@@ -22,16 +21,13 @@ type Registrar interface {
 }
 
 // getBinaryPath returns the absolute path to the current executable
+// Note: This does NOT resolve symlinks to ensure stability with package managers
+// like Homebrew that use symlinks to stable paths (e.g., /opt/homebrew/bin/switchboard)
+// rather than versioned paths (e.g., /opt/homebrew/Cellar/switchboard/1.0.1/bin/switchboard)
 func getBinaryPath() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("failed to get executable path: %w", err)
-	}
-
-	// Resolve symlinks
-	exe, err = filepath.EvalSymlinks(exe)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
 	}
 
 	return exe, nil


### PR DESCRIPTION
## Summary

- Removed `filepath.EvalSymlinks()` call in `getBinaryPath()` to prevent symlink resolution
- Handler path now uses stable symlink paths instead of versioned Cellar paths
- Homebrew upgrades will no longer break URL handling functionality

## Changes

The key change is in `internal/registration/registration.go` where we removed the symlink resolution logic. This ensures that when Homebrew installs switchboard, the registered handler path will be `/opt/homebrew/bin/switchboard` (stable symlink) instead of `/opt/homebrew/Cellar/switchboard/1.0.1/bin/switchboard` (versioned path).

## Testing

- All existing tests pass
- Linter passes with no issues
- Build successful

## Fixes

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)