### PR TITLE
Add RPM package support for Red Hat-based distributions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,29 @@ changelog:
     - title: "Other Changes"
       order: 999
 
+nfpms:
+  - id: switchboard
+    package_name: switchboard
+    vendor: Nicky Gerritsen
+    homepage: https://github.com/nickygerritsen/switchboard
+    maintainer: Nicky Gerritsen <github@accounts.nickygerritsen.nl>
+    description: Smart URL router that opens links in different browsers
+    license: MIT
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: config.example.yaml
+        dst: /usr/share/doc/switchboard/config.example.yaml
+        type: config|noreplace
+      - src: switchboard.desktop
+        dst: /usr/share/applications/switchboard.desktop
+      - src: LICENSE
+        dst: /usr/share/licenses/switchboard/LICENSE
+    rpm:
+      summary: Smart URL router that opens links in different browsers
+      group: Applications/Internet
+
 release:
   github:
     owner: nickygerritsen

--- a/switchboard.desktop
+++ b/switchboard.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Switchboard
+Comment=Smart URL router that opens links in different browsers
+Exec=switchboard open %u
+Terminal=false
+Categories=Network;
+MimeType=x-scheme-handler/http;x-scheme-handler/https;


### PR DESCRIPTION
## Summary

Adds support for generating `.rpm` packages that can be installed on Red Hat-based Linux distributions (Fedora, RHEL, CentOS, Rocky Linux, AlmaLinux, etc.).

## Changes

- Added `nfpms` configuration to [.goreleaser.yml:75-96](.goreleaser.yml#L75-L96) for RPM package generation
- Created [switchboard.desktop](switchboard.desktop) file for desktop environment integration
- Configured package structure:
  - Binary: `/usr/bin/switchboard`
  - Config example: `/usr/share/doc/switchboard/config.example.yaml`
  - Desktop file: `/usr/share/applications/switchboard.desktop`
  - License: `/usr/share/licenses/switchboard/LICENSE`
- Support for both x86_64 and aarch64 architectures

## Installation

After this change, users will be able to install RPM packages with:

```bash
# Fedora
sudo dnf install switchboard-0.1.0-1.x86_64.rpm

# RHEL/CentOS
sudo yum install switchboard-0.1.0-1.x86_64.rpm
```

## Test plan

- [x] GoReleaser configuration validated with `goreleaser check`
- [x] All tests pass (`go test ./...`)
- [x] No linter warnings (`golangci-lint run`)
- [x] Project builds successfully (`go build ./...`)

Resolves #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)