### PR TITLE
Add automated Copr repository uploads for DNF/YUM installation

### DIFF
--- a/.github/workflows/upload-copr.yml
+++ b/.github/workflows/upload-copr.yml
@@ -1,0 +1,72 @@
+name: Upload to Copr
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  upload-rpm:
+    name: Upload RPM to Copr
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: release } = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('tag_name', release.tag_name);
+            core.setOutput('version', release.tag_name.replace(/^v/, ''));
+            return release;
+          result-encoding: string
+
+      - name: Download RPM artifacts
+        run: |
+          VERSION="${{ steps.get_release.outputs.version }}"
+
+          # Download x86_64 RPM
+          curl -L -o "switchboard-${VERSION}-1.x86_64.rpm" \
+            "https://github.com/${{ github.repository }}/releases/download/${{ steps.get_release.outputs.tag_name }}/switchboard-${VERSION}-1.x86_64.rpm"
+
+          # Download aarch64 RPM
+          curl -L -o "switchboard-${VERSION}-1.aarch64.rpm" \
+            "https://github.com/${{ github.repository }}/releases/download/${{ steps.get_release.outputs.tag_name }}/switchboard-${VERSION}-1.aarch64.rpm"
+
+          ls -lh *.rpm
+
+      - name: Install copr-cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          pip3 install copr-cli
+
+      - name: Configure copr-cli
+        run: |
+          mkdir -p ~/.config
+          echo "${{ secrets.COPR_API_TOKEN }}" > ~/.config/copr
+          chmod 600 ~/.config/copr
+
+      - name: Upload to Copr
+        run: |
+          VERSION="${{ steps.get_release.outputs.version }}"
+
+          # Upload x86_64 RPM (will be available to all x86_64 chroots)
+          echo "Uploading x86_64 RPM..."
+          copr-cli add-package-rpms --name switchboard nickygerritsen/switchboard \
+            "switchboard-${VERSION}-1.x86_64.rpm"
+
+          # Upload aarch64 RPM (will be available to all aarch64 chroots)
+          echo "Uploading aarch64 RPM..."
+          copr-cli add-package-rpms --name switchboard nickygerritsen/switchboard \
+            "switchboard-${VERSION}-1.aarch64.rpm"
+
+          echo "Upload complete!"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ brew install nickygerritsen/tap/switchboard
 
 After installation, run `switchboard register` to make it available as a browser in your system settings.
 
+### Fedora/RHEL/CentOS (DNF/YUM)
+
+```bash
+# Enable the Copr repository
+sudo dnf copr enable nickygerritsen/switchboard
+
+# Install switchboard
+sudo dnf install switchboard
+```
+
+For RHEL/CentOS systems using yum:
+```bash
+sudo yum copr enable nickygerritsen/switchboard
+sudo yum install switchboard
+```
+
+After installation, run `switchboard register` to make it available as a browser in your system settings.
+
 ### Building from Source
 
 ```bash


### PR DESCRIPTION
## Summary

Adds automated uploads of RPM packages to Copr (Cool Other Package Repo), Fedora's community build system. This enables easy installation on Fedora, RHEL, CentOS, Rocky Linux, and AlmaLinux distributions.

## Changes

- Added [.github/workflows/upload-copr.yml](.github/workflows/upload-copr.yml) workflow that:
  - Triggers after successful Release workflow completion
  - Downloads x86_64 and aarch64 RPM packages from GitHub releases
  - Installs and configures `copr-cli`
  - Uploads RPMs to `nickygerritsen/switchboard` Copr project
  - Makes packages available to all enabled chroots automatically

- Updated [README.md:50-66](README.md#L50-L66) with installation instructions for DNF/YUM package managers

## User Experience

After this change, users can install switchboard with:

```bash
# Enable the Copr repository
sudo dnf copr enable nickygerritsen/switchboard

# Install switchboard
sudo dnf install switchboard
```

## Copr Project

The Copr project is configured at: https://copr.fedorainfracloud.org/coprs/nickygerritsen/switchboard/

Enabled for:
- Fedora 41, 42, 43, rawhide (x86_64, aarch64)
- EPEL 9, 10 (x86_64, aarch64)

## Test Plan

- [x] All tests pass (`go test ./...`)
- [x] No linter warnings (`golangci-lint run`)
- [x] Project builds successfully (`go build ./...`)
- [x] Workflow YAML syntax validated
- [x] Copr project created and configured
- [x] API token added to GitHub secrets
- [ ] Will be tested on next release

Resolves #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)