### PR TITLE
fix: pass VERSION to Copr builds via environment variable

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,44 +1,11 @@
 srpm:
-	@echo "=== DEBUG: Git environment ==="
-	@echo "Current directory: $$(pwd)"
-	@echo "Git branch/commit: $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached')"
-	@echo "Git commit SHA: $$(git rev-parse HEAD 2>/dev/null)"
-
-	@echo ""
-	@echo "=== DEBUG: Fetching tags ==="
-	@git fetch --tags 2>&1 || echo "git fetch --tags failed"
-
-	@echo ""
-	@echo "=== DEBUG: Available tags ==="
-	@git tag -l 2>&1 || echo "git tag -l failed"
-
-	@echo ""
-	@echo "=== DEBUG: Tags pointing at HEAD ==="
-	@git tag --points-at HEAD 2>&1 || echo "git tag --points-at HEAD failed"
-
-	@echo ""
-	@echo "=== DEBUG: git describe attempts ==="
-	@echo "Method 1 (exact match): $$(git describe --tags --exact-match 2>&1 | head -1)"
-	@echo "Method 2 (describe): $$(git describe --tags 2>&1 | head -1)"
-	@echo "Method 3 (points-at): $$(git tag --points-at HEAD | grep '^v' | head -1)"
-
-	@echo ""
-	@echo "=== DEBUG: Extracting version ==="
-	@VERSION=$$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') && \
-	if [ -z "$$VERSION" ]; then \
-		VERSION=$$(git describe --tags 2>/dev/null | sed 's/^v//' | sed 's/-.*//'); \
-	fi && \
-	if [ -z "$$VERSION" ]; then \
-		VERSION=$$(git tag --points-at HEAD 2>/dev/null | grep '^v' | sed 's/^v//' | head -1); \
-	fi && \
-	if [ -z "$$VERSION" ]; then \
-		echo "ERROR: VERSION could not be determined from git tags"; \
+	@echo "=== Building SRPM ==="
+	@if [ -z "$(VERSION)" ]; then \
+		echo "ERROR: VERSION environment variable not set"; \
 		exit 1; \
-	fi && \
-	echo "Extracted VERSION: $$VERSION" && \
-	echo "" && \
-	echo "=== Building SRPM for version: $$VERSION ===" && \
-	sed "s/__VERSION__/$$VERSION/g" switchboard.spec > $(outdir)/switchboard.spec && \
+	fi
+	@echo "Using VERSION: $(VERSION)"
+	@sed "s/__VERSION__/$(VERSION)/g" switchboard.spec > $(outdir)/switchboard.spec && \
 	rpmbuild -bs --define "_sourcedir $(CURDIR)" \
 		--define "_specdir $(outdir)" \
 		--define "_builddir $(CURDIR)" \

--- a/.github/workflows/upload-copr.yml
+++ b/.github/workflows/upload-copr.yml
@@ -71,6 +71,6 @@ jobs:
           VERSION="${{ steps.get_release.outputs.version }}"
 
           echo "Triggering build for version $VERSION (tag $TAG)..."
-          copr-cli build-package nickygerritsen/switchboard --name switchboard
+          copr-cli build-package nickygerritsen/switchboard --name switchboard --env "VERSION=$VERSION"
 
           echo "Build triggered! Monitor at: https://copr.fedorainfracloud.org/coprs/nickygerritsen/switchboard/builds/"


### PR DESCRIPTION
## Summary
- Fix Copr build failures by passing VERSION via environment variable
- Remove dependency on git during SRPM creation
- Simplify Makefile to only use VERSION env var

## Root Cause
The debug output from #51 revealed that git is not installed in the Copr SRPM build environment. All git commands were failing with:
```
git: command not found
```

The spec file's `BuildRequires: git` only applies during RPM building, not SRPM creation.

## Solution
1. **Workflow change**: Pass VERSION to copr-cli using `--env "VERSION=$VERSION"`
2. **Makefile change**: Remove all git-based version extraction, just use `$(VERSION)` environment variable

The workflow already extracts the version from the GitHub release, so we can pass it directly instead of trying to re-extract it with git.

## Testing
After merge, re-push v1.0.3-test to trigger a build with the updated code.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)