### PR TITLE
fix: add git to Copr buildroot for SRPM creation

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,11 +1,31 @@
 srpm:
 	@echo "=== Building SRPM ==="
-	@if [ -z "$(VERSION)" ]; then \
-		echo "ERROR: VERSION environment variable not set"; \
+	@echo "DEBUG: Checking for git..."
+	@which git || echo "ERROR: git not found in PATH"
+	@git --version || echo "ERROR: git command failed"
+	@echo ""
+	@echo "DEBUG: Current commit and tags..."
+	@git rev-parse HEAD || echo "ERROR: git rev-parse failed"
+	@git tag -l | head -5 || echo "ERROR: git tag -l failed"
+	@echo ""
+	@echo "DEBUG: Attempting version extraction..."
+	@VERSION=$$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') && \
+	echo "Method 1 (exact-match): $$VERSION" && \
+	if [ -z "$$VERSION" ]; then \
+		VERSION=$$(git describe --tags 2>/dev/null | sed 's/^v//' | sed 's/-.*//'); \
+		echo "Method 2 (describe): $$VERSION"; \
+	fi && \
+	if [ -z "$$VERSION" ]; then \
+		VERSION=$$(git tag --points-at HEAD 2>/dev/null | grep '^v' | sed 's/^v//' | head -1); \
+		echo "Method 3 (points-at): $$VERSION"; \
+	fi && \
+	if [ -z "$$VERSION" ]; then \
+		echo "ERROR: VERSION could not be determined from git tags"; \
 		exit 1; \
-	fi
-	@echo "Using VERSION: $(VERSION)"
-	@sed "s/__VERSION__/$(VERSION)/g" switchboard.spec > $(outdir)/switchboard.spec && \
+	fi && \
+	echo "" && \
+	echo "=== Using VERSION: $$VERSION ===" && \
+	sed "s/__VERSION__/$$VERSION/g" switchboard.spec > $(outdir)/switchboard.spec && \
 	rpmbuild -bs --define "_sourcedir $(CURDIR)" \
 		--define "_specdir $(outdir)" \
 		--define "_builddir $(CURDIR)" \

--- a/.github/workflows/upload-copr.yml
+++ b/.github/workflows/upload-copr.yml
@@ -44,6 +44,22 @@ jobs:
           echo "${{ secrets.COPR_API_TOKEN }}" > ~/.config/copr
           chmod 600 ~/.config/copr
 
+      - name: Add git to buildroot
+        run: |
+          # Get all enabled chroots for the project
+          echo "Getting enabled chroots for nickygerritsen/switchboard..."
+          CHROOTS=$(copr-cli get nickygerritsen/switchboard | grep -E '^\s+[a-z].*:' | awk '{print $1}' | tr -d ':')
+
+          echo "Found chroots:"
+          echo "$CHROOTS"
+          echo ""
+
+          # Add git to all chroots so it's available during SRPM creation
+          for chroot in $CHROOTS; do
+            echo "Adding git to $chroot..."
+            copr-cli edit-chroot nickygerritsen/switchboard/$chroot --packages "git"
+          done
+
       - name: Configure SCM package
         run: |
           TAG="${{ steps.get_release.outputs.tag_name }}"
@@ -71,6 +87,6 @@ jobs:
           VERSION="${{ steps.get_release.outputs.version }}"
 
           echo "Triggering build for version $VERSION (tag $TAG)..."
-          copr-cli build-package nickygerritsen/switchboard --name switchboard --env "VERSION=$VERSION"
+          copr-cli build-package nickygerritsen/switchboard --name switchboard
 
           echo "Build triggered! Monitor at: https://copr.fedorainfracloud.org/coprs/nickygerritsen/switchboard/builds/"


### PR DESCRIPTION
## Summary
- Install git in all Copr chroots so it's available during SRPM creation
- Dynamically fetch enabled chroots instead of hardcoding them
- Add debug output to Makefile to verify git works
- Use git-based version extraction in Makefile

## Root Cause
The debug output from #51 showed that git is not installed by default in the SRPM build environment. The spec file's `BuildRequires: git` only applies during RPM building, not SRPM creation.

## Solution
1. **Workflow**: Add step to run `copr-cli edit-chroot --packages "git"` for all enabled chroots
2. **Dynamic chroots**: Use `copr-cli get` to fetch enabled chroots instead of hardcoding
3. **Makefile**: Revert to git-based version extraction with debug output

## Testing
After merge, re-push v1.0.3-test. The workflow will:
1. Install git in all chroots
2. Configure the SCM package
3. Trigger builds that can now use git for version extraction

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)