### PR TITLE
fix: correct spec file path in Makefile

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -25,8 +25,8 @@ srpm:
 	fi && \
 	echo "" && \
 	echo "=== Using VERSION: $$VERSION ===" && \
-	sed "s/__VERSION__/$$VERSION/g" switchboard.spec > $(outdir)/switchboard.spec && \
-	rpmbuild -bs --define "_sourcedir $(CURDIR)" \
+	sed "s/__VERSION__/$$VERSION/g" ../switchboard.spec > $(outdir)/switchboard.spec && \
+	rpmbuild -bs --define "_sourcedir $(CURDIR)/.." \
 		--define "_specdir $(outdir)" \
 		--define "_builddir $(CURDIR)" \
 		--define "_srcrpmdir $(outdir)" \


### PR DESCRIPTION
Fixes path to switchboard.spec since Makefile runs from .copr/ directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)