### PR TITLE
fix: download source tarball for SRPM build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -26,7 +26,7 @@ srpm:
 	echo "" && \
 	echo "=== Using VERSION: $$VERSION ===" && \
 	sed "s/__VERSION__/$$VERSION/g" ../switchboard.spec > $(outdir)/switchboard.spec && \
-	rpmbuild -bs --define "_sourcedir $(CURDIR)/.." \
+	rpmbuild -bs --define "_sourcedir $$HOME/rpmbuild/SOURCES" \
 		--define "_specdir $(outdir)" \
 		--define "_builddir $(CURDIR)" \
 		--define "_srcrpmdir $(outdir)" \

--- a/.github/workflows/upload-copr.yml
+++ b/.github/workflows/upload-copr.yml
@@ -51,12 +51,18 @@ jobs:
 
       - name: Build SRPM locally
         run: |
+          TAG="${{ steps.get_release.outputs.tag_name }}"
           VERSION="${{ steps.get_release.outputs.version }}"
 
           echo "Building SRPM for version $VERSION..."
 
           # Create rpmbuild directories
           mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+          # Download the source tarball from GitHub
+          echo "Downloading source tarball..."
+          curl -L -o ~/rpmbuild/SOURCES/v${VERSION}.tar.gz \
+            "https://github.com/nickygerritsen/switchboard/archive/${TAG}.tar.gz"
 
           # Run make srpm target (it will use git which is available here)
           make -C .copr -f Makefile srpm outdir=$HOME/rpmbuild/SRPMS


### PR DESCRIPTION
rpmbuild needs the source tarball in _sourcedir. Download it from GitHub first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)